### PR TITLE
refactor: rename default_settings to settings

### DIFF
--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -46,12 +46,10 @@ from .conservation_rules import (
     parity_conservation,
     spin_magnitude_conservation,
 )
-from .default_settings import (
-    ADDITIONAL_PARTICLES_DEFINITIONS_PATH,
-    InteractionTypes,
-)
 from .particle import ParticleCollection, load_pdg
 from .quantum_numbers import InteractionProperties
+from .settings import InteractionTypes
+from .settings.defaults import ADDITIONAL_PARTICLES_DEFINITIONS_PATH
 from .solving import (
     GraphSettings,
     NodeSettings,

--- a/src/qrules/_system_control.py
+++ b/src/qrules/_system_control.py
@@ -6,7 +6,6 @@ from typing import Callable, Dict, List, Optional, Set, Tuple, Type
 
 import attr
 
-from .default_settings import InteractionTypes
 from .particle import Particle, ParticleCollection, ParticleWithSpin
 from .quantum_numbers import (
     EdgeQuantumNumber,
@@ -16,6 +15,7 @@ from .quantum_numbers import (
     NodeQuantumNumbers,
     Parity,
 )
+from .settings import InteractionTypes
 from .solving import GraphEdgePropertyMap, GraphNodePropertyMap, GraphSettings
 from .topology import StateTransitionGraph
 

--- a/src/qrules/settings/__init__.py
+++ b/src/qrules/settings/__init__.py
@@ -2,18 +2,14 @@
 
 from copy import deepcopy
 from enum import Enum, auto
-from os.path import dirname, join, realpath
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
-from .conservation_rules import (
+from qrules.conservation_rules import (
     BaryonNumberConservation,
     BottomnessConservation,
     ChargeConservation,
     CharmConservation,
-    ConservationRule,
-    EdgeQNConservationRule,
     ElectronLNConservation,
-    GraphElementRule,
     MassConservation,
     MuonLNConservation,
     StrangenessConservation,
@@ -33,47 +29,14 @@ from .conservation_rules import (
     spin_magnitude_conservation,
     spin_validity,
 )
-from .quantum_numbers import EdgeQuantumNumbers, NodeQuantumNumbers, arange
-from .solving import EdgeSettings, NodeSettings
-
-__QRULES_PATH = dirname(realpath(__file__))
-__DEFAULT_PARTICLE_LIST_FILE = "additional_definitions.yml"
-ADDITIONAL_PARTICLES_DEFINITIONS_PATH = join(
-    __QRULES_PATH, __DEFAULT_PARTICLE_LIST_FILE
+from qrules.quantum_numbers import (
+    EdgeQuantumNumbers,
+    NodeQuantumNumbers,
+    arange,
 )
+from qrules.solving import EdgeSettings, NodeSettings
 
-# If a conservation law is not listed here, a default priority of 1 is assumed.
-# Higher number means higher priority
-__CONSERVATION_LAW_PRIORITIES: Dict[
-    Union[GraphElementRule, EdgeQNConservationRule, ConservationRule], int
-] = {
-    spin_conservation: 8,
-    ls_spin_validity: 89,
-    spin_magnitude_conservation: 8,
-    helicity_conservation: 7,
-    MassConservation: 10,
-    ChargeConservation: 100,
-    ElectronLNConservation: 45,
-    MuonLNConservation: 44,
-    TauLNConservation: 43,
-    BaryonNumberConservation: 90,
-    identical_particle_symmetrization: 2,
-    CharmConservation: 70,
-    StrangenessConservation: 69,
-    parity_conservation: 6,
-    c_parity_conservation: 5,
-    parity_conservation_helicity: 4,
-    isospin_conservation: 60,
-    g_parity_conservation: 3,
-    BottomnessConservation: 68,
-}
-
-
-__EDGE_RULE_PRIORITIES: Dict[GraphElementRule, int] = {
-    gellmann_nishijima: 50,
-    isospin_validity: 61,
-    spin_validity: 62,
-}
+from .defaults import CONSERVATION_LAW_PRIORITIES, EDGE_RULE_PRIORITIES
 
 
 class InteractionTypes(Enum):
@@ -84,15 +47,12 @@ class InteractionTypes(Enum):
     WEAK = auto()
 
 
-def create_default_interaction_settings(
+def create_interaction_settings(
     formalism_type: str,
     nbody_topology: bool = False,
     mass_conservation_factor: Optional[float] = 3.0,
 ) -> Dict[InteractionTypes, Tuple[EdgeSettings, NodeSettings]]:
-    """Create a container that holds the settings for the various interactions.
-
-    E.g.: strong, em and weak interaction.
-    """
+    """Create a container that holds the settings for `.InteractionTypes`."""
     interaction_type_settings = {}
     formalism_edge_settings = EdgeSettings(
         conservation_rules={
@@ -100,7 +60,7 @@ def create_default_interaction_settings(
             gellmann_nishijima,
             spin_validity,
         },
-        rule_priorities=__EDGE_RULE_PRIORITIES,
+        rule_priorities=EDGE_RULE_PRIORITIES,
         qn_domains={
             EdgeQuantumNumbers.charge: [-2, -1, 0, 1, 2],
             EdgeQuantumNumbers.baryon_number: [-1, 0, 1],
@@ -124,7 +84,7 @@ def create_default_interaction_settings(
         },
     )
     formalism_node_settings = NodeSettings(
-        rule_priorities=__CONSERVATION_LAW_PRIORITIES
+        rule_priorities=CONSERVATION_LAW_PRIORITIES
     )
 
     if "helicity" in formalism_type:

--- a/src/qrules/settings/defaults.py
+++ b/src/qrules/settings/defaults.py
@@ -46,24 +46,24 @@ CONSERVATION_LAW_PRIORITIES: Dict[
     Union[GraphElementRule, EdgeQNConservationRule, ConservationRule], int
 ] = {
     spin_conservation: 8,
-    ls_spin_validity: 89,
     spin_magnitude_conservation: 8,
-    helicity_conservation: 7,
     MassConservation: 10,
     ChargeConservation: 100,
     ElectronLNConservation: 45,
     MuonLNConservation: 44,
     TauLNConservation: 43,
     BaryonNumberConservation: 90,
-    identical_particle_symmetrization: 2,
-    CharmConservation: 70,
     StrangenessConservation: 69,
+    CharmConservation: 70,
+    BottomnessConservation: 68,
     parity_conservation: 6,
     c_parity_conservation: 5,
-    parity_conservation_helicity: 4,
-    isospin_conservation: 60,
     g_parity_conservation: 3,
-    BottomnessConservation: 68,
+    isospin_conservation: 60,
+    ls_spin_validity: 89,
+    helicity_conservation: 7,
+    parity_conservation_helicity: 4,
+    identical_particle_symmetrization: 2,
 }
 """Determines the order with which to verify conservation rules."""
 

--- a/src/qrules/settings/defaults.py
+++ b/src/qrules/settings/defaults.py
@@ -1,0 +1,75 @@
+"""Default settings for the framework.
+
+It is possible to change these settings from the outside, like:
+
+>>> from qrules.settings import defaults
+>>> defaults.MAX_ANGULAR_MOMENTUM = 4
+"""
+
+from os.path import dirname, join, realpath
+from typing import Dict, Union
+
+from qrules.conservation_rules import (
+    BaryonNumberConservation,
+    BottomnessConservation,
+    ChargeConservation,
+    CharmConservation,
+    ConservationRule,
+    EdgeQNConservationRule,
+    ElectronLNConservation,
+    GraphElementRule,
+    MassConservation,
+    MuonLNConservation,
+    StrangenessConservation,
+    TauLNConservation,
+    c_parity_conservation,
+    g_parity_conservation,
+    gellmann_nishijima,
+    helicity_conservation,
+    identical_particle_symmetrization,
+    isospin_conservation,
+    isospin_validity,
+    ls_spin_validity,
+    parity_conservation,
+    parity_conservation_helicity,
+    spin_conservation,
+    spin_magnitude_conservation,
+    spin_validity,
+)
+
+__QRULES_PATH = dirname(dirname(realpath(__file__)))
+ADDITIONAL_PARTICLES_DEFINITIONS_PATH: str = join(
+    __QRULES_PATH, "additional_definitions.yml"
+)
+
+CONSERVATION_LAW_PRIORITIES: Dict[
+    Union[GraphElementRule, EdgeQNConservationRule, ConservationRule], int
+] = {
+    spin_conservation: 8,
+    ls_spin_validity: 89,
+    spin_magnitude_conservation: 8,
+    helicity_conservation: 7,
+    MassConservation: 10,
+    ChargeConservation: 100,
+    ElectronLNConservation: 45,
+    MuonLNConservation: 44,
+    TauLNConservation: 43,
+    BaryonNumberConservation: 90,
+    identical_particle_symmetrization: 2,
+    CharmConservation: 70,
+    StrangenessConservation: 69,
+    parity_conservation: 6,
+    c_parity_conservation: 5,
+    parity_conservation_helicity: 4,
+    isospin_conservation: 60,
+    g_parity_conservation: 3,
+    BottomnessConservation: 68,
+}
+"""Determines the order with which to verify conservation rules."""
+
+
+EDGE_RULE_PRIORITIES: Dict[GraphElementRule, int] = {
+    gellmann_nishijima: 50,
+    isospin_validity: 61,
+    spin_validity: 62,
+}

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -28,10 +28,6 @@ from .combinatorics import (
     create_initial_facts,
     match_external_edges,
 )
-from .default_settings import (
-    InteractionTypes,
-    create_default_interaction_settings,
-)
 from .particle import Particle, ParticleCollection, ParticleWithSpin, load_pdg
 from .quantum_numbers import (
     EdgeQuantumNumber,
@@ -40,6 +36,7 @@ from .quantum_numbers import (
     NodeQuantumNumber,
     NodeQuantumNumbers,
 )
+from .settings import InteractionTypes, create_interaction_settings
 from .solving import (
     CSPSolver,
     EdgeSettings,
@@ -331,12 +328,10 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                 mass_conservation_factor = None
 
         if not self.interaction_type_settings:
-            self.interaction_type_settings = (
-                create_default_interaction_settings(
-                    formalism_type,
-                    nbody_topology=use_nbody_topology,
-                    mass_conservation_factor=mass_conservation_factor,
-                )
+            self.interaction_type_settings = create_interaction_settings(
+                formalism_type,
+                nbody_topology=use_nbody_topology,
+                mass_conservation_factor=mass_conservation_factor,
             )
 
         if reload_pdg or len(self.__particles) == 0:

--- a/tests/unit/test_parity_prefactor.py
+++ b/tests/unit/test_parity_prefactor.py
@@ -2,7 +2,7 @@ from typing import NamedTuple, Tuple
 
 import pytest
 
-from qrules.default_settings import InteractionTypes
+from qrules.settings import InteractionTypes
 from qrules.transition import StateTransitionManager
 
 

--- a/tests/unit/test_reaction.py
+++ b/tests/unit/test_reaction.py
@@ -1,7 +1,7 @@
 import pytest
 
 from qrules import _determine_interaction_types
-from qrules.default_settings import InteractionTypes as IT  # noqa: N817
+from qrules.settings import InteractionTypes as IT  # noqa: N817
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,11 +1,11 @@
 import pytest
 
-from qrules.default_settings import (
+from qrules.quantum_numbers import EdgeQuantumNumbers, NodeQuantumNumbers
+from qrules.settings import (
     InteractionTypes,
     _halves_range,
-    create_default_interaction_settings,
+    create_interaction_settings,
 )
-from qrules.quantum_numbers import EdgeQuantumNumbers, NodeQuantumNumbers
 
 
 @pytest.mark.parametrize("interaction_type", list(InteractionTypes))
@@ -13,14 +13,12 @@ from qrules.quantum_numbers import EdgeQuantumNumbers, NodeQuantumNumbers
 @pytest.mark.parametrize(
     "formalism_type", ["canonical", "canonical-helicity", "helicity"]
 )
-def test_create_default_interaction_settings(
+def test_create_interaction_settings(
     interaction_type: InteractionTypes,
     nbody_topology: bool,
     formalism_type: str,
 ):
-    settings = create_default_interaction_settings(
-        formalism_type, nbody_topology
-    )
+    settings = create_interaction_settings(formalism_type, nbody_topology)
     assert set(settings) == set(InteractionTypes)
 
     edge_settings, node_settings = settings[interaction_type]


### PR DESCRIPTION
Creates two different namespaces, `settings` and its subspace `settings.defaults`. The `settings` module is long-term, as it contains functions that _produce_ settings, while `defaults` should eventually be abandoned for some settings class.