### PR TITLE
feat: determine domains from ParticleCollection

### DIFF
--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -48,8 +48,12 @@ from .conservation_rules import (
 )
 from .particle import ParticleCollection, load_pdg
 from .quantum_numbers import InteractionProperties
-from .settings import InteractionTypes
-from .settings.defaults import ADDITIONAL_PARTICLES_DEFINITIONS_PATH
+from .settings import InteractionTypes, _halves_domain, _int_domain
+from .settings.defaults import (
+    ADDITIONAL_PARTICLES_DEFINITIONS_PATH,
+    MAX_ANGULAR_MOMENTUM,
+    MAX_SPIN_MAGNITUDE,
+)
 from .solving import (
     GraphSettings,
     NodeSettings,
@@ -194,7 +198,10 @@ def check_reaction_violations(
     # if it is a two body reaction
     ls_combinations = [
         InteractionProperties(l_magnitude=l_magnitude, s_magnitude=s_magnitude)
-        for l_magnitude, s_magnitude in product([0, 1], [0, 0.5, 1, 1.5, 2])
+        for l_magnitude, s_magnitude in product(
+            _int_domain(0, MAX_ANGULAR_MOMENTUM),
+            _halves_domain(0, MAX_SPIN_MAGNITUDE),
+        )
     ]
 
     initial_facts_list = []

--- a/src/qrules/quantum_numbers.py
+++ b/src/qrules/quantum_numbers.py
@@ -182,7 +182,7 @@ class InteractionProperties:
 
 
 def arange(
-    x_1: float, x_2: float, delta: float
+    x_1: float, x_2: float, delta: float = 1.0
 ) -> Generator[float, None, None]:
     current = Decimal(x_1)
     while current < x_2:

--- a/src/qrules/settings/__init__.py
+++ b/src/qrules/settings/__init__.py
@@ -29,11 +29,9 @@ from qrules.conservation_rules import (
     spin_magnitude_conservation,
     spin_validity,
 )
-from qrules.quantum_numbers import (
-    EdgeQuantumNumbers,
-    NodeQuantumNumbers,
-    arange,
-)
+from qrules.quantum_numbers import EdgeQuantumNumbers as EdgeQN
+from qrules.quantum_numbers import NodeQuantumNumbers as NodeQN
+from qrules.quantum_numbers import arange
 from qrules.solving import EdgeSettings, NodeSettings
 
 from .defaults import (
@@ -66,25 +64,23 @@ def create_interaction_settings(
         },
         rule_priorities=EDGE_RULE_PRIORITIES,
         qn_domains={
-            EdgeQuantumNumbers.charge: [-2, -1, 0, 1, 2],
-            EdgeQuantumNumbers.baryon_number: [-1, 0, 1],
-            EdgeQuantumNumbers.electron_lepton_number: [-1, 0, 1],
-            EdgeQuantumNumbers.muon_lepton_number: [-1, 0, 1],
-            EdgeQuantumNumbers.tau_lepton_number: [-1, 0, 1],
-            EdgeQuantumNumbers.parity: [-1, 1],
-            EdgeQuantumNumbers.c_parity: [-1, 1, None],
-            EdgeQuantumNumbers.g_parity: [-1, 1, None],
-            EdgeQuantumNumbers.spin_magnitude: _halves_range(0, 2),
-            EdgeQuantumNumbers.spin_projection: __create_projections(
-                _halves_range(0, 2)
+            EdgeQN.charge: [-2, -1, 0, 1, 2],
+            EdgeQN.baryon_number: [-1, 0, 1],
+            EdgeQN.electron_lepton_number: [-1, 0, 1],
+            EdgeQN.muon_lepton_number: [-1, 0, 1],
+            EdgeQN.tau_lepton_number: [-1, 0, 1],
+            EdgeQN.parity: [-1, 1],
+            EdgeQN.c_parity: [-1, 1, None],
+            EdgeQN.g_parity: [-1, 1, None],
+            EdgeQN.spin_magnitude: _halves_domain(0, 2),
+            EdgeQN.spin_projection: __extend_negative(_halves_domain(0, 2)),
+            EdgeQN.isospin_magnitude: _halves_domain(0, 1.5),
+            EdgeQN.isospin_projection: __extend_negative(
+                _halves_domain(0, 1.5)
             ),
-            EdgeQuantumNumbers.isospin_magnitude: _halves_range(0, 1.5),
-            EdgeQuantumNumbers.isospin_projection: __create_projections(
-                _halves_range(0, 1.5)
-            ),
-            EdgeQuantumNumbers.charmness: [-1, 0, 1],
-            EdgeQuantumNumbers.strangeness: [-1, 0, 1],
-            EdgeQuantumNumbers.bottomness: [-1, 0, 1],
+            EdgeQN.charmness: [-1, 0, 1],
+            EdgeQN.strangeness: [-1, 0, 1],
+            EdgeQN.bottomness: [-1, 0, 1],
         },
     )
     formalism_node_settings = NodeSettings(
@@ -97,12 +93,8 @@ def create_interaction_settings(
             helicity_conservation,
         }
         formalism_node_settings.qn_domains = {
-            NodeQuantumNumbers.l_magnitude: _get_ang_mom_magnitudes(
-                nbody_topology
-            ),
-            NodeQuantumNumbers.s_magnitude: _get_spin_magnitudes(
-                nbody_topology
-            ),
+            NodeQN.l_magnitude: _get_ang_mom_magnitudes(nbody_topology),
+            NodeQN.s_magnitude: _get_spin_magnitudes(nbody_topology),
         }
     elif formalism_type == "canonical":
         formalism_node_settings.conservation_rules = {
@@ -114,16 +106,12 @@ def create_interaction_settings(
                 ls_spin_validity,
             }
         formalism_node_settings.qn_domains = {
-            NodeQuantumNumbers.l_magnitude: _get_ang_mom_magnitudes(
-                nbody_topology
-            ),
-            NodeQuantumNumbers.l_projection: __create_projections(
+            NodeQN.l_magnitude: _get_ang_mom_magnitudes(nbody_topology),
+            NodeQN.l_projection: __extend_negative(
                 _get_ang_mom_magnitudes(nbody_topology)
             ),
-            NodeQuantumNumbers.s_magnitude: _get_spin_magnitudes(
-                nbody_topology
-            ),
-            NodeQuantumNumbers.s_projection: __create_projections(
+            NodeQN.s_magnitude: _get_spin_magnitudes(nbody_topology),
+            NodeQN.s_projection: __extend_negative(
                 _get_spin_magnitudes(nbody_topology)
             ),
         }
@@ -136,8 +124,8 @@ def create_interaction_settings(
         )
         formalism_node_settings.qn_domains.update(
             {
-                NodeQuantumNumbers.l_projection: [0],
-                NodeQuantumNumbers.s_projection: __create_projections(
+                NodeQN.l_projection: [0],
+                NodeQN.s_projection: __extend_negative(
                     _get_spin_magnitudes(nbody_topology)
                 ),
             }
@@ -178,9 +166,7 @@ def create_interaction_settings(
     )
     if "helicity" in formalism_type:
         em_node_settings.conservation_rules.add(parity_conservation_helicity)
-        em_node_settings.qn_domains.update(
-            {NodeQuantumNumbers.parity_prefactor: [-1, 1]}
-        )
+        em_node_settings.qn_domains.update({NodeQN.parity_prefactor: [-1, 1]})
     em_node_settings.interaction_strength = 1
 
     em_edge_settings = deepcopy(weak_edge_settings)
@@ -209,22 +195,16 @@ def create_interaction_settings(
 def _get_ang_mom_magnitudes(is_nbody: bool) -> List[float]:
     if is_nbody:
         return [0]
-    return list(range(0, MAX_ANGULAR_MOMENTUM + 1))
-
-
-def __create_projections(
-    magnitudes: Iterable[Union[int, float]]
-) -> List[Union[int, float]]:
-    return sorted(list(magnitudes) + [-x for x in magnitudes if x > 0])
+    return _int_domain(0, MAX_ANGULAR_MOMENTUM)  # type: ignore
 
 
 def _get_spin_magnitudes(is_nbody: bool) -> List[float]:
     if is_nbody:
         return [0]
-    return _halves_range(0, 2)
+    return _halves_domain(0, 2)
 
 
-def _halves_range(start: float, stop: float) -> List[float]:
+def _halves_domain(start: float, stop: float) -> List[float]:
     if start % 0.5 != 0.0:
         raise ValueError(f"Start value {start} needs to be multiple of 0.5")
     if stop % 0.5 != 0.0:
@@ -233,3 +213,13 @@ def _halves_range(start: float, stop: float) -> List[float]:
         int(v) if v.is_integer() else v
         for v in arange(start, stop + 0.25, delta=0.5)
     ]
+
+
+def _int_domain(start: int, stop: int) -> List[int]:
+    return list(range(start, stop + 1))
+
+
+def __extend_negative(
+    magnitudes: Iterable[Union[int, float]]
+) -> List[Union[int, float]]:
+    return sorted(list(magnitudes) + [-x for x in magnitudes if x > 0])

--- a/src/qrules/settings/__init__.py
+++ b/src/qrules/settings/__init__.py
@@ -39,6 +39,7 @@ from .defaults import (
     CONSERVATION_LAW_PRIORITIES,
     EDGE_RULE_PRIORITIES,
     MAX_ANGULAR_MOMENTUM,
+    MAX_SPIN_MAGNITUDE,
 )
 
 
@@ -183,7 +184,7 @@ def _get_ang_mom_magnitudes(is_nbody: bool) -> List[float]:
 def _get_spin_magnitudes(is_nbody: bool) -> List[float]:
     if is_nbody:
         return [0]
-    return _halves_domain(0, 2)
+    return _halves_domain(0, MAX_SPIN_MAGNITUDE)
 
 
 def _create_domains(particles: ParticleCollection) -> Dict[Any, list]:

--- a/src/qrules/settings/defaults.py
+++ b/src/qrules/settings/defaults.py
@@ -45,10 +45,7 @@ ADDITIONAL_PARTICLES_DEFINITIONS_PATH: str = join(
 CONSERVATION_LAW_PRIORITIES: Dict[
     Union[GraphElementRule, EdgeQNConservationRule, ConservationRule], int
 ] = {
-    spin_conservation: 8,
-    spin_magnitude_conservation: 8,
     MassConservation: 10,
-    ChargeConservation: 100,
     ElectronLNConservation: 45,
     MuonLNConservation: 44,
     TauLNConservation: 43,
@@ -56,6 +53,9 @@ CONSERVATION_LAW_PRIORITIES: Dict[
     StrangenessConservation: 69,
     CharmConservation: 70,
     BottomnessConservation: 68,
+    ChargeConservation: 100,
+    spin_conservation: 8,
+    spin_magnitude_conservation: 8,
     parity_conservation: 6,
     c_parity_conservation: 5,
     g_parity_conservation: 3,

--- a/src/qrules/settings/defaults.py
+++ b/src/qrules/settings/defaults.py
@@ -4,6 +4,7 @@ It is possible to change these settings from the outside, like:
 
 >>> from qrules.settings import defaults
 >>> defaults.MAX_ANGULAR_MOMENTUM = 4
+>>> defaults.MAX_SPIN_MAGNITUDE = 3
 """
 
 from os.path import dirname, join, realpath
@@ -75,7 +76,7 @@ EDGE_RULE_PRIORITIES: Dict[GraphElementRule, int] = {
 }
 
 MAX_ANGULAR_MOMENTUM: int = 2
-"""Maximum angular momentum over which to generate transitions.
+"""Maximum angular momentum over which to generate :math:`LS`-couplings."""
 
-Is used in particular by `.create_interaction_settings`.
-"""
+MAX_SPIN_MAGNITUDE: int = 2
+"""Maximum spin magnitude over which to generate :math:`LS`-couplings."""

--- a/src/qrules/solving.py
+++ b/src/qrules/solving.py
@@ -62,7 +62,7 @@ class EdgeSettings:
 
     conservation_rules: Set[GraphElementRule] = attr.ib(factory=set)
     rule_priorities: Dict[GraphElementRule, int] = attr.ib(factory=dict)
-    qn_domains: Dict[Any, Any] = attr.ib(factory=dict)
+    qn_domains: Dict[Any, list] = attr.ib(factory=dict)
 
 
 @attr.s
@@ -81,7 +81,7 @@ class NodeSettings:
 
     conservation_rules: Set[Rule] = attr.ib(factory=set)
     rule_priorities: Dict[Rule, int] = attr.ib(factory=dict)
-    qn_domains: Dict[Any, Any] = attr.ib(factory=dict)
+    qn_domains: Dict[Any, list] = attr.ib(factory=dict)
     interaction_strength: float = 1.0
 
 

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -327,15 +327,16 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             if len(initial_state) > 1:
                 mass_conservation_factor = None
 
+        if reload_pdg or len(self.__particles) == 0:
+            self.__particles = load_pdg()
+
         if not self.interaction_type_settings:
             self.interaction_type_settings = create_interaction_settings(
                 formalism_type,
+                particles=self.__particles,
                 nbody_topology=use_nbody_topology,
                 mass_conservation_factor=mass_conservation_factor,
             )
-
-        if reload_pdg or len(self.__particles) == 0:
-            self.__particles = load_pdg()
 
         self.__user_allowed_intermediate_particles = (
             allowed_intermediate_particles

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,9 +1,9 @@
 import pytest
 
-from qrules.quantum_numbers import EdgeQuantumNumbers, NodeQuantumNumbers
 from qrules.settings import (
     InteractionTypes,
-    _halves_range,
+    _halves_domain,
+    _int_domain,
     create_interaction_settings,
 )
 
@@ -22,44 +22,54 @@ def test_create_interaction_settings(
     assert set(settings) == set(InteractionTypes)
 
     edge_settings, node_settings = settings[interaction_type]
-    assert edge_settings.qn_domains == {
-        EdgeQuantumNumbers.baryon_number: [-1, 0, 1],
-        EdgeQuantumNumbers.electron_lepton_number: [-1, 0, 1],
-        EdgeQuantumNumbers.muon_lepton_number: [-1, 0, 1],
-        EdgeQuantumNumbers.tau_lepton_number: [-1, 0, 1],
-        EdgeQuantumNumbers.parity: [-1, 1],
-        EdgeQuantumNumbers.c_parity: [-1, 1, None],
-        EdgeQuantumNumbers.g_parity: [-1, 1, None],
-        EdgeQuantumNumbers.spin_magnitude: _halves_range(0, 2),
-        EdgeQuantumNumbers.spin_projection: _halves_range(-2, +2),
-        EdgeQuantumNumbers.charge: [-2, -1, 0, 1, 2],
-        EdgeQuantumNumbers.isospin_magnitude: _halves_range(0, 1.5),
-        EdgeQuantumNumbers.isospin_projection: _halves_range(-1.5, +1.5),
-        EdgeQuantumNumbers.strangeness: [-1, 0, 1],
-        EdgeQuantumNumbers.charmness: [-1, 0, 1],
-        EdgeQuantumNumbers.bottomness: [-1, 0, 1],
+    edge_qn_domains_str = {  # strings are easier to compare with pytest
+        qn_type.__name__: domain
+        for qn_type, domain in edge_settings.qn_domains.items()
     }
+    assert edge_qn_domains_str == {
+        "baryon_number": [-1, 0, +1],
+        "electron_lepton_number": [-1, 0, +1],
+        "muon_lepton_number": [-1, 0, +1],
+        "tau_lepton_number": [-1, 0, +1],
+        "parity": [-1, +1],
+        "c_parity": [-1, +1, None],
+        "g_parity": [-1, +1, None],
+        "spin_magnitude": _halves_domain(0, 2),
+        "spin_projection": _halves_domain(-2, +2),
+        "charge": _int_domain(-2, 2),
+        "isospin_magnitude": _halves_domain(0, 1.5),
+        "isospin_projection": _halves_domain(-1.5, +1.5),
+        "strangeness": _int_domain(-1, 1),
+        "charmness": _int_domain(-1, 1),
+        "bottomness": _int_domain(-1, 1),
+    }
+
     expected = {
-        NodeQuantumNumbers.l_magnitude: [0, 1, 2],
-        NodeQuantumNumbers.s_magnitude: _halves_range(0, 2),
+        "l_magnitude": _int_domain(0, 2),
+        "s_magnitude": _halves_domain(0, 2),
     }
     if "canonical" in formalism_type:
-        expected[NodeQuantumNumbers.l_projection] = [-2, -1, 0, 1, 2]
-        expected[NodeQuantumNumbers.s_projection] = _halves_range(-2, 2)
+        expected["l_projection"] = [-2, -1, 0, 1, 2]
+        expected["s_projection"] = _halves_domain(-2, 2)
     if formalism_type == "canonical-helicity":
-        expected[NodeQuantumNumbers.l_projection] = [0]
+        expected["l_projection"] = [0]
     if (
         "helicity" in formalism_type
         and interaction_type != InteractionTypes.WEAK
     ):
-        expected[NodeQuantumNumbers.parity_prefactor] = [-1, 1]
+        expected["parity_prefactor"] = [-1, 1]
     if nbody_topology:
-        expected[NodeQuantumNumbers.l_magnitude] = [0]
-        expected[NodeQuantumNumbers.s_magnitude] = [0]
+        expected["l_magnitude"] = [0]
+        expected["s_magnitude"] = [0]
     if nbody_topology and formalism_type != "helicity":
-        expected[NodeQuantumNumbers.l_projection] = [0]
-        expected[NodeQuantumNumbers.s_projection] = [0]
-    assert node_settings.qn_domains == expected
+        expected["l_projection"] = [0]
+        expected["s_projection"] = [0]
+
+    node_qn_domains_str = {  # strings are easier to compare with pytest
+        qn_type.__name__: domain
+        for qn_type, domain in node_settings.qn_domains.items()
+    }
+    assert node_qn_domains_str == expected
 
 
 @pytest.mark.parametrize(
@@ -73,6 +83,6 @@ def test_create_interaction_settings(
 def test_halves_range(start: float, stop: float, expected: list):
     if expected is None:
         with pytest.raises(ValueError):
-            _halves_range(start, stop)
+            _halves_domain(start, stop)
     else:
-        assert _halves_range(start, stop) == expected
+        assert _halves_domain(start, stop) == expected


### PR DESCRIPTION
From https://github.com/ComPWA/expertsystem/pull/486, but adapted so that ranges are generated: if there is some `Particle` in the inserted `ParticleCollection` with spin-1.5, the range will be `[0, 0.5, 1, 1.5]` (not just `[1.5]`). Also allows setting the maximum spin in _LS_-couplings.

This will facilitate #40 