### PR TITLE
refactor: rename to InteractionType

### DIFF
--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qrules import InteractionTypes, StateTransitionManager\n",
+    "from qrules import InteractionType, StateTransitionManager\n",
     "\n",
     "stm = StateTransitionManager(\n",
     "    initial_state=[\"J/psi(1S)\"],\n",
@@ -122,7 +122,7 @@
     "\n",
     "  * `.create_problem_sets` of the STM creates all problem sets ― using the boundary conditions of the `.StateTransitionManager` instance. In total 3 steps are performed. The creation of reaction topologies. The creation of `.InitialFacts`, based on a topology and the initial and final state information. And finally the solving settings such as the conservation laws and quantum number domains to use at which point of the topology.\n",
     "\n",
-    "  * By default, all three interaction types (`~.InteractionTypes.EM`, `~.InteractionTypes.STRONG`, and `~.InteractionTypes.WEAK`) are used in the preparation stage. However, it is also possible to choose the allowed interaction types globally via `.set_allowed_interaction_types`.\n",
+    "  * By default, all three interaction types (`~.InteractionType.EM`, `~.InteractionType.STRONG`, and `~.InteractionType.WEAK`) are used in the preparation stage. However, it is also possible to choose the allowed interaction types globally via `.set_allowed_interaction_types`.\n",
     "\n",
     "  After the preparation step, you can modify the problem sets returned by `.create_problem_sets` to your liking. Since the output of this function contains quite a lot of information, {mod}`qrules` aids in the configuration (especially the STM).\n",
     "\n",
@@ -253,7 +253,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In general, you can modify the {class}`.ProblemSet`s returned by {meth}`~.StateTransitionManager.create_problem_sets` directly, but the STM also comes with functionality to globally choose the allowed interaction types. So, go ahead and **disable** the {attr}`~.InteractionTypes.EM` and {attr}`.InteractionTypes.WEAK` interactions:"
+    "In general, you can modify the {class}`.ProblemSet`s returned by {meth}`~.StateTransitionManager.create_problem_sets` directly, but the STM also comes with functionality to globally choose the allowed interaction types. So, go ahead and **disable** the {attr}`~.InteractionType.EM` and {attr}`.InteractionType.WEAK` interactions:"
    ]
   },
   {
@@ -262,7 +262,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stm.set_allowed_interaction_types([InteractionTypes.STRONG])\n",
+    "stm.set_allowed_interaction_types([InteractionType.STRONG])\n",
     "problem_sets = stm.create_problem_sets()\n",
     "result = stm.find_solutions(problem_sets)\n",
     "\n",
@@ -287,9 +287,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stm.set_allowed_interaction_types(\n",
-    "    [InteractionTypes.STRONG, InteractionTypes.EM]\n",
-    ")\n",
+    "stm.set_allowed_interaction_types([InteractionType.STRONG, InteractionType.EM])\n",
     "problem_sets = stm.create_problem_sets()\n",
     "result = stm.find_solutions(problem_sets)\n",
     "\n",

--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -48,7 +48,7 @@ from .conservation_rules import (
 )
 from .particle import ParticleCollection, load_pdg
 from .quantum_numbers import InteractionProperties
-from .settings import InteractionTypes, _halves_domain, _int_domain
+from .settings import InteractionType, _halves_domain, _int_domain
 from .settings.defaults import (
     ADDITIONAL_PARTICLES_DEFINITIONS_PATH,
     MAX_ANGULAR_MOMENTUM,
@@ -288,8 +288,8 @@ def generate_transitions(  # pylint: disable=too-many-arguments
 
         allowed_interaction_types (`str`, optional): Interaction types you want
             to consider. For instance, both :code:`"strong and EM"` and
-            :code:`["s", "em"]` results in `~.InteractionTypes.EM` and
-            `~.InteractionTypes.STRONG`.
+            :code:`["s", "em"]` results in `~.InteractionType.EM` and
+            `~.InteractionType.STRONG`.
 
         formalism_type (`str`, optional): Formalism that you intend to use in
             the eventual amplitude model.
@@ -357,8 +357,8 @@ def generate_transitions(  # pylint: disable=too-many-arguments
 
 def _determine_interaction_types(
     description: Union[str, List[str]]
-) -> Set[InteractionTypes]:
-    interaction_types: Set[InteractionTypes] = set()
+) -> Set[InteractionType]:
+    interaction_types: Set[InteractionType] = set()
     if isinstance(description, list):
         for i in description:
             interaction_types.update(
@@ -374,18 +374,18 @@ def _determine_interaction_types(
         raise ValueError('Provided an empty interaction name ("")')
     interaction_name_lower = description.lower()
     if "all" in interaction_name_lower:
-        for interaction in InteractionTypes:
+        for interaction in InteractionType:
             interaction_types.add(interaction)
     if (
         "em" in interaction_name_lower
         or "ele" in interaction_name_lower
         or interaction_name_lower.startswith("e")
     ):
-        interaction_types.add(InteractionTypes.EM)
+        interaction_types.add(InteractionType.EM)
     if "w" in interaction_name_lower:
-        interaction_types.add(InteractionTypes.WEAK)
+        interaction_types.add(InteractionType.WEAK)
     if "strong" in interaction_name_lower or interaction_name_lower == "s":
-        interaction_types.add(InteractionTypes.STRONG)
+        interaction_types.add(InteractionType.STRONG)
     if len(interaction_types) == 0:
         raise ValueError(
             f'Could not determine interaction type from "{description}"'

--- a/src/qrules/_system_control.py
+++ b/src/qrules/_system_control.py
@@ -15,7 +15,7 @@ from .quantum_numbers import (
     NodeQuantumNumbers,
     Parity,
 )
-from .settings import InteractionTypes
+from .settings import InteractionType
 from .solving import GraphEdgePropertyMap, GraphNodePropertyMap, GraphSettings
 from .topology import StateTransitionGraph
 
@@ -124,9 +124,9 @@ def create_interaction_properties(
 
 
 def filter_interaction_types(
-    valid_determined_interaction_types: List[InteractionTypes],
-    allowed_interaction_types: List[InteractionTypes],
-) -> List[InteractionTypes]:
+    valid_determined_interaction_types: List[InteractionType],
+    allowed_interaction_types: List[InteractionType],
+) -> List[InteractionType]:
     int_type_intersection = list(
         set(allowed_interaction_types)
         & set(valid_determined_interaction_types)
@@ -152,7 +152,7 @@ class InteractionDeterminator(ABC):
         in_edge_props: List[ParticleWithSpin],
         out_edge_props: List[ParticleWithSpin],
         node_props: InteractionProperties,
-    ) -> List[InteractionTypes]:
+    ) -> List[InteractionType]:
         pass
 
 
@@ -164,11 +164,11 @@ class GammaCheck(InteractionDeterminator):
         in_edge_props: List[ParticleWithSpin],
         out_edge_props: List[ParticleWithSpin],
         node_props: InteractionProperties,
-    ) -> List[InteractionTypes]:
-        int_types = list(InteractionTypes)
+    ) -> List[InteractionType]:
+        int_types = list(InteractionType)
         for particle, _ in in_edge_props + out_edge_props:
             if "gamma" in particle.name:
-                int_types = [InteractionTypes.EM]
+                int_types = [InteractionType.EM]
                 break
         return int_types
 
@@ -181,16 +181,16 @@ class LeptonCheck(InteractionDeterminator):
         in_edge_props: List[ParticleWithSpin],
         out_edge_props: List[ParticleWithSpin],
         node_props: InteractionProperties,
-    ) -> List[InteractionTypes]:
-        node_interaction_types = list(InteractionTypes)
+    ) -> List[InteractionType]:
+        node_interaction_types = list(InteractionType)
         for particle, _ in in_edge_props + out_edge_props:
             if particle.is_lepton():
                 if particle.name.startswith("nu("):
-                    node_interaction_types = [InteractionTypes.WEAK]
+                    node_interaction_types = [InteractionType.WEAK]
                     break
                 node_interaction_types = [
-                    InteractionTypes.EM,
-                    InteractionTypes.WEAK,
+                    InteractionType.EM,
+                    InteractionType.WEAK,
                 ]
         return node_interaction_types
 

--- a/src/qrules/settings/__init__.py
+++ b/src/qrules/settings/__init__.py
@@ -43,7 +43,7 @@ from .defaults import (
 )
 
 
-class InteractionTypes(Enum):
+class InteractionType(Enum):
     """Types of interactions in the form of an enumerate."""
 
     STRONG = auto()
@@ -56,8 +56,8 @@ def create_interaction_settings(
     particles: ParticleCollection,
     nbody_topology: bool = False,
     mass_conservation_factor: Optional[float] = 3.0,
-) -> Dict[InteractionTypes, Tuple[EdgeSettings, NodeSettings]]:
-    """Create a container that holds the settings for `.InteractionTypes`."""
+) -> Dict[InteractionType, Tuple[EdgeSettings, NodeSettings]]:
+    """Create a container that holds the settings for `.InteractionType`."""
     formalism_edge_settings = EdgeSettings(
         conservation_rules={
             isospin_validity,
@@ -134,7 +134,7 @@ def create_interaction_settings(
     weak_node_settings.interaction_strength = 10 ** (-4)
     weak_edge_settings = deepcopy(formalism_edge_settings)
 
-    interaction_type_settings[InteractionTypes.WEAK] = (
+    interaction_type_settings[InteractionType.WEAK] = (
         weak_edge_settings,
         weak_node_settings,
     )
@@ -155,7 +155,7 @@ def create_interaction_settings(
 
     em_node_settings.interaction_strength = 1
     em_edge_settings = deepcopy(weak_edge_settings)
-    interaction_type_settings[InteractionTypes.EM] = (
+    interaction_type_settings[InteractionType.EM] = (
         em_edge_settings,
         em_node_settings,
     )
@@ -167,7 +167,7 @@ def create_interaction_settings(
 
     strong_node_settings.interaction_strength = 60
     strong_edge_settings = deepcopy(em_edge_settings)
-    interaction_type_settings[InteractionTypes.STRONG] = (
+    interaction_type_settings[InteractionType.STRONG] = (
         strong_edge_settings,
         strong_node_settings,
     )

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -36,7 +36,7 @@ from .quantum_numbers import (
     NodeQuantumNumber,
     NodeQuantumNumbers,
 )
-from .settings import InteractionTypes, create_interaction_settings
+from .settings import InteractionType, create_interaction_settings
 from .solving import (
     CSPSolver,
     EdgeSettings,
@@ -258,7 +258,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         particles: Optional[ParticleCollection] = None,
         allowed_intermediate_particles: Optional[List[str]] = None,
         interaction_type_settings: Dict[
-            InteractionTypes, Tuple[EdgeSettings, NodeSettings]
+            InteractionType, Tuple[EdgeSettings, NodeSettings]
         ] = None,
         formalism_type: str = "helicity",
         topology_building: str = "isobar",
@@ -297,10 +297,10 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             GammaCheck(),
         ]
         self.final_state_groupings: Optional[List[List[List[str]]]] = None
-        self.allowed_interaction_types: List[InteractionTypes] = [
-            InteractionTypes.STRONG,
-            InteractionTypes.EM,
-            InteractionTypes.WEAK,
+        self.allowed_interaction_types: List[InteractionType] = [
+            InteractionType.STRONG,
+            InteractionType.EM,
+            InteractionType.WEAK,
         ]
         self.filter_remove_qns: Set[Type[NodeQuantumNumber]] = set()
         self.filter_ignore_qns: Set[Type[NodeQuantumNumber]] = set()
@@ -390,14 +390,14 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             self.final_state_groupings.append(fs_group)  # type: ignore
 
     def set_allowed_interaction_types(
-        self, allowed_interaction_types: List[InteractionTypes]
+        self, allowed_interaction_types: List[InteractionType]
     ) -> None:
         # verify order
         for allowed_types in allowed_interaction_types:
-            if not isinstance(allowed_types, InteractionTypes):
+            if not isinstance(allowed_types, InteractionType):
                 raise TypeError(
                     "allowed interaction types must be of type"
-                    "[InteractionTypes]"
+                    "[InteractionType]"
                 )
             if allowed_types not in self.interaction_type_settings:
                 logging.info(self.interaction_type_settings.keys())
@@ -445,7 +445,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                 intermediate_edge_domains[
                     EdgeQuantumNumbers.spin_projection
                 ].update(
-                    self.interaction_type_settings[InteractionTypes.WEAK][
+                    self.interaction_type_settings[InteractionType.WEAK][
                         0
                     ].qn_domains[EdgeQuantumNumbers.spin_projection]
                 )
@@ -463,7 +463,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                     }
                 )
 
-            return self.interaction_type_settings[InteractionTypes.WEAK][
+            return self.interaction_type_settings[InteractionType.WEAK][
                 0
             ].qn_domains
 
@@ -472,7 +472,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
 
         def create_edge_settings(edge_id: int) -> EdgeSettings:
             settings = copy(
-                self.interaction_type_settings[InteractionTypes.WEAK][0]
+                self.interaction_type_settings[InteractionType.WEAK][0]
             )
             if edge_id in intermediate_state_edges:
                 settings.qn_domains = int_edge_domains
@@ -494,7 +494,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         ]
 
         for node_id in topology.nodes:
-            interaction_types: List[InteractionTypes] = []
+            interaction_types: List[InteractionType] = []
             out_edge_ids = topology.get_edge_ids_outgoing_from_node(node_id)
             in_edge_ids = topology.get_edge_ids_outgoing_from_node(node_id)
             in_edge_props = [

--- a/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
+++ b/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
@@ -1,7 +1,7 @@
 import pytest
 
 import qrules as q
-from qrules import InteractionTypes, StateTransitionManager
+from qrules import InteractionType, StateTransitionManager
 
 
 @pytest.mark.parametrize(
@@ -40,7 +40,7 @@ def test_full(formalism_type, n_solutions, particle_database):
         formalism_type=formalism_type,
         number_of_threads=1,
     )
-    stm.set_allowed_interaction_types([InteractionTypes.STRONG])
+    stm.set_allowed_interaction_types([InteractionType.STRONG])
     stm.add_final_state_grouping([["D0", "pi0"], ["D~0", "pi0"]])
     problem_sets = stm.create_problem_sets()
     result = stm.find_solutions(problem_sets)

--- a/tests/unit/test_parity_prefactor.py
+++ b/tests/unit/test_parity_prefactor.py
@@ -2,7 +2,7 @@ from typing import NamedTuple, Tuple
 
 import pytest
 
-from qrules.settings import InteractionTypes
+from qrules.settings import InteractionType
 from qrules.transition import StateTransitionManager
 
 
@@ -60,7 +60,7 @@ def test_parity_prefactor(
         number_of_threads=1,
     )
     stm.add_final_state_grouping(test_input.final_state_grouping)
-    stm.set_allowed_interaction_types([InteractionTypes.EM])
+    stm.set_allowed_interaction_types([InteractionType.EM])
     problem_sets = stm.create_problem_sets()
 
     result = stm.find_solutions(problem_sets)

--- a/tests/unit/test_reaction.py
+++ b/tests/unit/test_reaction.py
@@ -1,7 +1,7 @@
 import pytest
 
 from qrules import _determine_interaction_types
-from qrules.settings import InteractionTypes as IT  # noqa: N817
+from qrules.settings import InteractionType as IT  # noqa: N817
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -3,7 +3,7 @@ import pytest
 from qrules.particle import ParticleCollection
 from qrules.quantum_numbers import EdgeQuantumNumbers as EdgeQN
 from qrules.settings import (
-    InteractionTypes,
+    InteractionType,
     _create_domains,
     _halves_domain,
     _int_domain,
@@ -30,14 +30,14 @@ def test_create_domains(particle_database: ParticleCollection):
     assert domains[EdgeQN.isospin_projection] == [-1, -0.5, 0, 0.5, 1]
 
 
-@pytest.mark.parametrize("interaction_type", list(InteractionTypes))
+@pytest.mark.parametrize("interaction_type", list(InteractionType))
 @pytest.mark.parametrize("nbody_topology", [False, True])
 @pytest.mark.parametrize(
     "formalism_type", ["canonical", "canonical-helicity", "helicity"]
 )
 def test_create_interaction_settings(
     particle_database: ParticleCollection,
-    interaction_type: InteractionTypes,
+    interaction_type: InteractionType,
     nbody_topology: bool,
     formalism_type: str,
 ):
@@ -46,7 +46,7 @@ def test_create_interaction_settings(
         particles=particle_database,
         nbody_topology=nbody_topology,
     )
-    assert set(settings) == set(InteractionTypes)
+    assert set(settings) == set(InteractionType)
 
     edge_settings, node_settings = settings[interaction_type]
     edge_qn_domains_str = {  # strings are easier to compare with pytest
@@ -82,7 +82,7 @@ def test_create_interaction_settings(
         expected["l_projection"] = [0]
     if (
         "helicity" in formalism_type
-        and interaction_type != InteractionTypes.WEAK
+        and interaction_type != InteractionType.WEAK
     ):
         expected["parity_prefactor"] = [-1, 1]
     if nbody_topology:

--- a/tests/unit/test_system_control.py
+++ b/tests/unit/test_system_control.py
@@ -4,7 +4,7 @@ from typing import List
 
 import pytest
 
-from qrules import InteractionTypes, ProblemSet, StateTransitionManager
+from qrules import InteractionType, ProblemSet, StateTransitionManager
 from qrules._system_control import (
     create_edge_properties,
     filter_graphs,
@@ -100,7 +100,7 @@ def test_external_edge_initialization(
         number_of_threads=1,
     )
 
-    stm.set_allowed_interaction_types([InteractionTypes.STRONG])
+    stm.set_allowed_interaction_types([InteractionType.STRONG])
     for group in final_state_groupings:
         stm.add_final_state_grouping(group)
 
@@ -363,7 +363,7 @@ def test_edge_swap(particle_database, initial_state, final_state):
         formalism_type="helicity",
         number_of_threads=1,
     )
-    stm.set_allowed_interaction_types([InteractionTypes.STRONG])
+    stm.set_allowed_interaction_types([InteractionType.STRONG])
 
     problem_sets = stm.create_problem_sets()
     init_graphs: List[StateTransitionGraph[ParticleWithSpin]] = []
@@ -410,7 +410,7 @@ def test_match_external_edges(particle_database, initial_state, final_state):
         number_of_threads=1,
     )
 
-    stm.set_allowed_interaction_types([InteractionTypes.STRONG])
+    stm.set_allowed_interaction_types([InteractionType.STRONG])
 
     problem_sets = stm.create_problem_sets()
     init_graphs: List[StateTransitionGraph[ParticleWithSpin]] = []
@@ -486,7 +486,7 @@ def test_external_edge_identical_particle_combinatorics(
         formalism_type="helicity",
         number_of_threads=1,
     )
-    stm.set_allowed_interaction_types([InteractionTypes.STRONG])
+    stm.set_allowed_interaction_types([InteractionType.STRONG])
     for group in final_state_groupings:
         stm.add_final_state_grouping(group)
 


### PR DESCRIPTION
Policy is that enums should be singular, so that the syntax makes more sense, especially in docstrings. For instance:
- Which `InteractionType`?
- Use `InteractionType.WEAK`

Same with the (already existing) `SolvingMode`.