### PR TITLE
ci: run notebooks with pytest

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -13,10 +13,10 @@ argon2-cffi==20.1.0
 astroid==2.5.6
 async-generator==1.10
 attrs==20.3.0
-babel==2.9.0
+babel==2.9.1
 backcall==0.2.0
 beautifulsoup4==4.9.3
-black==21.4b1
+black==21.4b2
 bleach==3.3.0
 certifi==2020.12.5
 cffi==1.14.5
@@ -130,6 +130,7 @@ pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
 pytest-forked==1.3.0
+pytest-notebook==0.6.1
 pytest-profiling==1.7.0
 pytest-xdist==2.2.1
 pytest==6.2.3

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -13,10 +13,10 @@ argon2-cffi==20.1.0
 astroid==2.5.6
 async-generator==1.10
 attrs==20.3.0
-babel==2.9.0
+babel==2.9.1
 backcall==0.2.0
 beautifulsoup4==4.9.3
-black==21.4b1
+black==21.4b2
 bleach==3.3.0
 certifi==2020.12.5
 cffi==1.14.5
@@ -53,6 +53,7 @@ identify==2.2.4
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==4.0.1
+importlib-resources==5.1.2
 iniconfig==1.1.1
 ipykernel==5.5.3
 ipython-genutils==0.2.0
@@ -126,6 +127,7 @@ pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
 pytest-forked==1.3.0
+pytest-notebook==0.6.1
 pytest-profiling==1.7.0
 pytest-xdist==2.2.1
 pytest==6.2.3

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -13,10 +13,10 @@ argon2-cffi==20.1.0
 astroid==2.5.6
 async-generator==1.10
 attrs==20.3.0
-babel==2.9.0
+babel==2.9.1
 backcall==0.2.0
 beautifulsoup4==4.9.3
-black==21.4b1
+black==21.4b2
 bleach==3.3.0
 certifi==2020.12.5
 cffi==1.14.5
@@ -53,6 +53,7 @@ identify==2.2.4
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==4.0.1
+importlib-resources==5.1.2
 iniconfig==1.1.1
 ipykernel==5.5.3
 ipython-genutils==0.2.0
@@ -126,6 +127,7 @@ pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
 pytest-forked==1.3.0
+pytest-notebook==0.6.1
 pytest-profiling==1.7.0
 pytest-xdist==2.2.1
 pytest==6.2.3

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -13,10 +13,10 @@ argon2-cffi==20.1.0
 astroid==2.5.6
 async-generator==1.10
 attrs==20.3.0
-babel==2.9.0
+babel==2.9.1
 backcall==0.2.0
 beautifulsoup4==4.9.3
-black==21.4b1
+black==21.4b2
 bleach==3.3.0
 certifi==2020.12.5
 cffi==1.14.5
@@ -53,6 +53,7 @@ identify==2.2.4
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==4.0.1
+importlib-resources==5.1.2
 iniconfig==1.1.1
 ipykernel==5.5.3
 ipython-genutils==0.2.0
@@ -126,6 +127,7 @@ pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
 pytest-forked==1.3.0
+pytest-notebook==0.6.1
 pytest-profiling==1.7.0
 pytest-xdist==2.2.1
 pytest==6.2.3

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,10 +8,18 @@ addopts =
     --doctest-continue-on-failure
     --doctest-modules
     --durations=3
+    --ignore=docs/conf.py
 filterwarnings =
     error
+nb_diff_ignore =
+    /cells/*/execution_count
+    /cells/*/outputs
+    /metadata/widgets
+norecursedirs =
+    _build
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
 testpaths =
+    docs
     src
     tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -106,6 +106,7 @@ dev =
     jupyterlab
     jupyterlab-code-formatter
     pip-tools >= 6.1.0  # for extras_require
+    pytest-notebook
     sphinx-autobuild
     tox >= 1.9  # for skip_install, use_develop
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ test =
     pydot
     pytest
     pytest-cov
+    pytest-notebook
     pytest-profiling
     pytest-xdist
 format =
@@ -106,7 +107,6 @@ dev =
     jupyterlab
     jupyterlab-code-formatter
     pip-tools >= 6.1.0  # for extras_require
-    pytest-notebook
     sphinx-autobuild
     tox >= 1.9  # for skip_install, use_develop
 

--- a/tox.ini
+++ b/tox.ini
@@ -120,3 +120,13 @@ commands =
         --cov-report=html \
         --cov-report=xml \
         --cov=qrules
+
+[testenv:testnb]
+description =
+    Run all notebooks with pytest
+allowlist_externals =
+    pytest
+passenv =
+    EXECUTE_NB
+commands =
+    pytest {posargs:docs} --nb-test-files


### PR DESCRIPTION
Provides a faster way of running all notebooks. Usage:

```shell
tox -e testnb
EXECUTE_NB=yes  tox -e testnb  # as if run by Sphinx
```
or
```shell
poytest --nb-test-files  # all tests and notebooks
pytest docs --nb-test-files
pytest docs --nb-test-files  -n auto  # parallel
```

Rest of the configuration, such as ignoring cell output, is provided through `pytest.ini`. For further info, see [`pytest-notebook`](https://pytest-notebook.readthedocs.io/en/stable).

Note that the notebooks are still run through Sphinx on the CI. This is to ensure the rendering on RTD works correctly. `pytest-notebook` is therefore only installed through the `dev` extras, not through the `test` extras.