### PR TITLE
docs: improve documentation on interaction properties

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,7 @@ autodoc_default_options = {
     "special-members": ", ".join(
         [
             "__call__",
+            "__getitem__",
         ]
     ),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,6 @@ autodoc_default_options = {
     "special-members": ", ".join(
         [
             "__call__",
-            "__eq__",
         ]
     ),
 }

--- a/src/qrules/conservation_rules.py
+++ b/src/qrules/conservation_rules.py
@@ -807,8 +807,8 @@ def clebsch_gordan_helicity_to_canonical(
     coupling based on the conversion of helicity to canonical amplitude sums.
 
     .. note:: This rule does not check that the spin magnitudes couple
-      correctly to L and S, as this is already performed by
-      `~.spin_magnitude_conservation`.
+      correctly to :math:`L` and :math:`S`, as this is already performed by
+      `.spin_magnitude_conservation`.
     """
     if len(ingoing_spins) == 1 and len(outgoing_spins) == 2:
         out_spin1 = _Spin(

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -63,7 +63,7 @@ __REQUIRED_TOPOLOGY_FIELDS = {
 def asdot(
     instance: object,
     *,
-    render_node: bool = True,
+    render_node: bool = False,
     render_final_state_id: bool = True,
     render_resonance_id: bool = False,
     render_initial_state_id: bool = False,

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -75,6 +75,34 @@ def asdot(
     Only works for objects that can be represented as a graph, particularly a
     `.StateTransitionGraph` or a `list` of `.StateTransitionGraph` instances.
 
+    Args:
+        instance: the input `object` that is to be rendered as DOT (graphviz)
+            language.
+
+        strip_spin: Normally, each `.StateTransitionGraph` has a `.Particle`
+            with a spin projection on its edges. This option hides the
+            projections, leaving only `.Particle` names on edges.
+
+        collapse_graphs: Group all transitions by equivalent kinematic topology
+            and combine all allowed particles on each edge.
+
+        render_node: Whether or not to render node ID (in the case of a
+            `.Topology`) and/or node properties (in the case of a
+            `.StateTransitionGraph`). Meaning of the labels:
+
+            - :math:`P`: parity prefactor
+            - :math:`s`: tuple of **coupled spin** magnitude and its
+              projection
+            - :math:`l`: tuple of **angular momentum** and its projection
+
+            See `.InteractionProperties` for more info.
+
+        render_final_state_id: Add edge IDs for the final state edges.
+
+        render_resonance_id: Add edge IDs for the intermediate state edges.
+
+        render_initial_state_id: Add edge IDs for the initial state edges.
+
     .. seealso:: :doc:`/usage/visualize`
     """
     if isinstance(instance, (StateTransitionGraph, Topology)):

--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -47,8 +47,17 @@ def graph_list_to_dot(
     if strip_spin and collapse_graphs:
         raise ValueError("Cannot both strip spin and collapse graphs")
     if collapse_graphs:
+        if render_node:
+            raise ValueError(
+                "Collapsed graphs cannot be rendered with node properties"
+            )
         graphs = _collapse_graphs(graphs)
     elif strip_spin:
+        if render_node:
+            raise ValueError(
+                "Graphs without spin projections cannot be rendered with node"
+                " properties"
+            )
         graphs = _get_particle_graphs(graphs)
     dot = ""
     for i, graph in enumerate(reversed(graphs)):

--- a/src/qrules/quantum_numbers.py
+++ b/src/qrules/quantum_numbers.py
@@ -160,6 +160,15 @@ def _to_optional_int(optional_int: Optional[int]) -> Optional[int]:
 class InteractionProperties:
     """Immutable data structure containing interaction properties.
 
+    Interactions are represented by a node on a `.StateTransitionGraph`. This
+    class represents the properties that are carried collectively by the edges
+    that this node connects.
+
+    Interaction properties are in particular important in the canonical basis
+    of the helicity formalism. There, the *coupled spin* and angular momentum
+    of each interaction are used for the Clebsch-Gordan coefficients for each
+    term in a sequential amplitude.
+
     .. note:: As opposed to `NodeQuantumNumbers`, the `InteractionProperties`
         class serves as an interface to the user.
     """

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -36,15 +36,17 @@ import attr
 
 from .quantum_numbers import InteractionProperties
 
-_K = TypeVar("_K")
-_V = TypeVar("_V")
+KeyType = TypeVar("KeyType")
+"""Type the keys of the `~typing.Mapping`, see `~typing.KeysView`."""
+ValueType = TypeVar("ValueType")
+"""Type the value of the `~typing.Mapping`, see `~typing.ValuesView`."""
 
 
 class FrozenDict(  # pylint: disable=too-many-ancestors
-    Generic[_K, _V], abc.Hashable, abc.Mapping
+    Generic[KeyType, ValueType], abc.Hashable, abc.Mapping
 ):
     def __init__(self, mapping: Optional[Mapping] = None):
-        self.__mapping: Dict[_K, _V] = {}
+        self.__mapping: Dict[KeyType, ValueType] = {}
         if mapping is not None:
             self.__mapping = dict(mapping)
         self.__hash = hash(None)
@@ -56,25 +58,25 @@ class FrozenDict(  # pylint: disable=too-many-ancestors
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.__mapping})"
 
-    def __iter__(self) -> Iterator[_K]:
+    def __iter__(self) -> Iterator[KeyType]:
         return iter(self.__mapping)
 
     def __len__(self) -> int:
         return len(self.__mapping)
 
-    def __getitem__(self, key: _K) -> _V:
+    def __getitem__(self, key: KeyType) -> ValueType:
         return self.__mapping[key]
 
     def __hash__(self) -> int:
         return self.__hash
 
-    def keys(self) -> KeysView[_K]:
+    def keys(self) -> KeysView[KeyType]:
         return self.__mapping.keys()
 
-    def items(self) -> ItemsView[_K, _V]:
+    def items(self) -> ItemsView[KeyType, ValueType]:
         return self.__mapping.items()
 
-    def values(self) -> ValuesView[_V]:
+    def values(self) -> ValuesView[ValueType]:
         return self.__mapping.values()
 
 


### PR DESCRIPTION
It's not well documented what the labels of an interaction node mean (see for instance [this graph visualization](https://qrules.readthedocs.io/en/0.8.1/usage.html#investigate-intermediate-resonances)).

Also fixes some other minor issues:
- It doesn't make sense to render node properties for collapsed graphs of state transition graphs without spin projections on the edges, so `io.asdot` now raises an exception if you try to use `render_node=True` with `collapse_graph=True` or `strip_spin=True`.
- Rendering of special methods in the API has been improved.