### PR TITLE
style: avoid using import qrules as q

### DIFF
--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -83,9 +83,9 @@
    },
    "outputs": [],
    "source": [
-    "import qrules as q\n",
+    "import qrules\n",
     "\n",
-    "result = q.generate_transitions(\n",
+    "result = qrules.generate_transitions(\n",
     "    initial_state=\"J/psi(1S)\",\n",
     "    final_state=[\"K0\", \"Sigma+\", \"p~\"],\n",
     "    allowed_interaction_types=\"strong\",\n",
@@ -101,7 +101,7 @@
    "source": [
     "import graphviz\n",
     "\n",
-    "dot = q.io.asdot(result, collapse_graphs=True)\n",
+    "dot = qrules.io.asdot(result, collapse_graphs=True)\n",
     "graphviz.Source(dot)"
    ]
   },
@@ -154,9 +154,9 @@
    },
    "outputs": [],
    "source": [
-    "import qrules as q\n",
+    "import qrules\n",
     "\n",
-    "pdg = q.load_pdg()\n",
+    "pdg = qrules.load_pdg()\n",
     "pdg.find(22)  # by pid\n",
     "pdg.find(\"Delta(1920)++\")"
    ]
@@ -217,7 +217,7 @@
    },
    "outputs": [],
    "source": [
-    "q.check_reaction_violations(\n",
+    "qrules.check_reaction_violations(\n",
     "    initial_state=\"pi0\",\n",
     "    final_state=[\"gamma\", \"gamma\", \"gamma\"],\n",
     ")"

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -168,9 +168,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import qrules as q\n",
+    "import qrules\n",
     "\n",
-    "result = q.generate_transitions(\n",
+    "result = qrules.generate_transitions(\n",
     "    initial_state=\"psi(2S)\",\n",
     "    final_state=[\"gamma\", \"eta\", \"eta\"],\n",
     "    allowed_interaction_types=\"EM\",\n",
@@ -190,7 +190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dot = q.io.asdot(result.transitions[::50][:3])  # just some selection"
+    "dot = qrules.io.asdot(result.transitions[::50][:3])  # just some selection"
    ]
   },
   {
@@ -219,7 +219,7 @@
    "source": [
     "import graphviz\n",
     "\n",
-    "dot = q.io.asdot(\n",
+    "dot = qrules.io.asdot(\n",
     "    result.transitions[::50][:3], render_node=False\n",
     ")  # just some selection\n",
     "graphviz.Source(dot)"
@@ -238,7 +238,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q.io.write(result, \"decay_topologies_with_spin.gv\")"
+    "qrules.io.write(result, \"decay_topologies_with_spin.gv\")"
    ]
   },
   {
@@ -261,7 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dot = q.io.asdot(result.transitions[:3], strip_spin=True)\n",
+    "dot = qrules.io.asdot(result.transitions[:3], strip_spin=True)\n",
     "graphviz.Source(dot)"
    ]
   },
@@ -287,7 +287,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dot = q.io.asdot(result, collapse_graphs=True, render_node=False)\n",
+    "dot = qrules.io.asdot(result, collapse_graphs=True, render_node=False)\n",
     "graphviz.Source(dot)"
    ]
   }

--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -107,8 +107,8 @@ def check_reaction_violations(  # pylint: disable=too-many-arguments
       number configurations.
 
     Example:
-        >>> import qrules as q
-        >>> q.check_reaction_violations(
+        >>> import qrules
+        >>> qrules.check_reaction_violations(
         ...     initial_state="pi0",
         ...     final_state=["gamma", "gamma", "gamma"],
         ... )
@@ -347,14 +347,14 @@ def generate_transitions(  # pylint: disable=too-many-arguments
     An example (where, for illustrative purposes only, we specify all
     arguments) would be:
 
-    >>> import qrules as q
-    >>> result = q.generate_transitions(
+    >>> import qrules
+    >>> result = qrules.generate_transitions(
     ...     initial_state="D0",
     ...     final_state=["K~0", "K+", "K-"],
     ...     allowed_intermediate_particles=["a(0)(980)", "a(2)(1320)-"],
     ...     allowed_interaction_types="ew",
     ...     formalism_type="helicity",
-    ...     particle_db=q.load_pdg(),
+    ...     particle_db=qrules.load_pdg(),
     ...     topology_building="isobar",
     ... )
     >>> len(result.transitions)

--- a/src/qrules/settings.py
+++ b/src/qrules/settings.py
@@ -2,9 +2,9 @@
 
 It is possible to change some settings from the outside, for instance:
 
->>> import qrules as q
->>> q.settings.MAX_ANGULAR_MOMENTUM = 4
->>> q.settings.MAX_SPIN_MAGNITUDE = 3
+>>> import qrules
+>>> qrules.settings.MAX_ANGULAR_MOMENTUM = 4
+>>> qrules.settings.MAX_SPIN_MAGNITUDE = 3
 """
 
 from copy import deepcopy

--- a/tests/channels/test_d0_to_ks_kp_km.py
+++ b/tests/channels/test_d0_to_ks_kp_km.py
@@ -1,8 +1,8 @@
-import qrules as q
+import qrules
 
 
 def test_script():
-    result = q.generate_transitions(
+    result = qrules.generate_transitions(
         initial_state="D0",
         final_state=["K~0", "K+", "K-"],
         allowed_intermediate_particles=[

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -1,6 +1,6 @@
 import pytest
 
-import qrules as q
+import qrules
 from qrules.combinatorics import _create_edge_id_particle_mapping
 
 
@@ -27,7 +27,7 @@ from qrules.combinatorics import _create_edge_id_particle_mapping
 def test_number_of_solutions(
     particle_database, allowed_intermediate_particles, number_of_solutions
 ):
-    result = q.generate_transitions(
+    result = qrules.generate_transitions(
         initial_state=("J/psi(1S)", [-1, +1]),
         final_state=["gamma", "pi0", "pi0"],
         particle_db=particle_database,
@@ -42,7 +42,7 @@ def test_number_of_solutions(
 
 
 def test_id_to_particle_mappings(particle_database):
-    result = q.generate_transitions(
+    result = qrules.generate_transitions(
         initial_state=("J/psi(1S)", [-1, +1]),
         final_state=["gamma", "pi0", "pi0"],
         particle_db=particle_database,

--- a/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
+++ b/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
@@ -1,6 +1,6 @@
 import pytest
 
-import qrules as q
+import qrules
 from qrules import InteractionType, StateTransitionManager
 
 
@@ -12,7 +12,7 @@ from qrules import InteractionType, StateTransitionManager
     ],
 )
 def test_simple(formalism_type, n_solutions, particle_database):
-    result = q.generate_transitions(
+    result = qrules.generate_transitions(
         initial_state=[("Y(4260)", [-1, +1])],
         final_state=["D*(2007)0", "D*(2007)~0"],
         particle_db=particle_database,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,7 +3,7 @@ import logging
 
 import pytest
 
-import qrules as q
+import qrules
 from qrules import Result
 
 logging.basicConfig(level=logging.ERROR)
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.ERROR)
 
 @pytest.fixture(scope="session")
 def jpsi_to_gamma_pi_pi_canonical_solutions() -> Result:
-    return q.generate_transitions(
+    return qrules.generate_transitions(
         initial_state=[("J/psi(1S)", [-1, 1])],
         final_state=["gamma", "pi0", "pi0"],
         allowed_intermediate_particles=["f(0)(980)", "f(0)(1500)"],
@@ -22,7 +22,7 @@ def jpsi_to_gamma_pi_pi_canonical_solutions() -> Result:
 
 @pytest.fixture(scope="session")
 def jpsi_to_gamma_pi_pi_helicity_solutions() -> Result:
-    return q.generate_transitions(
+    return qrules.generate_transitions(
         initial_state=[("J/psi(1S)", [-1, 1])],
         final_state=["gamma", "pi0", "pi0"],
         allowed_intermediate_particles=["f(0)(980)", "f(0)(1500)"],


### PR DESCRIPTION
Use `import qrules` instead of `import qrules as q`, as it's not really needed to abbreviate this module.