### PR TITLE
refactor!: rename formalism_type to formalism

### DIFF
--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -89,7 +89,7 @@
     "    initial_state=\"J/psi(1S)\",\n",
     "    final_state=[\"K0\", \"Sigma+\", \"p~\"],\n",
     "    allowed_interaction_types=\"strong\",\n",
-    "    formalism_type=\"canonical-helicity\",\n",
+    "    formalism=\"canonical-helicity\",\n",
     ")"
    ]
   },

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -109,7 +109,7 @@
     "stm = StateTransitionManager(\n",
     "    initial_state=[\"J/psi(1S)\"],\n",
     "    final_state=[\"gamma\", \"pi0\", \"pi0\"],\n",
-    "    formalism_type=\"helicity\",\n",
+    "    formalism=\"helicity\",\n",
     ")"
    ]
   },

--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -283,7 +283,7 @@ def generate_transitions(  # pylint: disable=too-many-arguments
     final_state: Sequence[StateDefinition],
     allowed_intermediate_particles: Optional[List[str]] = None,
     allowed_interaction_types: Optional[Union[str, List[str]]] = None,
-    formalism_type: str = "helicity",
+    formalism: str = "helicity",
     particle_db: Optional[ParticleCollection] = None,
     mass_conservation_factor: Optional[float] = 3.0,
     max_angular_momentum: int = 2,
@@ -315,7 +315,7 @@ def generate_transitions(  # pylint: disable=too-many-arguments
             :code:`["s", "em"]` results in `~.InteractionType.EM` and
             `~.InteractionType.STRONG`.
 
-        formalism_type (`str`, optional): Formalism that you intend to use in
+        formalism (`str`, optional): Formalism that you intend to use in
             the eventual amplitude model.
 
         particle_db (`.ParticleCollection`, optional): The particles that you
@@ -353,7 +353,7 @@ def generate_transitions(  # pylint: disable=too-many-arguments
     ...     final_state=["K~0", "K+", "K-"],
     ...     allowed_intermediate_particles=["a(0)(980)", "a(2)(1320)-"],
     ...     allowed_interaction_types="ew",
-    ...     formalism_type="helicity",
+    ...     formalism="helicity",
     ...     particle_db=qrules.load_pdg(),
     ...     topology_building="isobar",
     ... )
@@ -371,7 +371,7 @@ def generate_transitions(  # pylint: disable=too-many-arguments
         final_state=final_state,
         particle_db=particle_db,
         allowed_intermediate_particles=allowed_intermediate_particles,
-        formalism_type=formalism_type,
+        formalism=formalism,
         mass_conservation_factor=mass_conservation_factor,
         max_angular_momentum=max_angular_momentum,
         max_spin_magnitude=max_spin_magnitude,

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -41,7 +41,7 @@ def fromdict(definition: dict) -> object:
         return _dict.build_particle(definition)
     if keys == {"particles"}:
         return _dict.build_particle_collection(definition)
-    if keys == {"transitions", "formalism_type"}:
+    if keys == {"transitions", "formalism"}:
         return _dict.build_result(definition)
     if keys == {"topology", "edge_props", "node_props"}:
         return _dict.build_stg(definition)

--- a/src/qrules/io/_dict.py
+++ b/src/qrules/io/_dict.py
@@ -37,8 +37,8 @@ def from_result(result: Result) -> dict:
     output: Dict[str, Any] = {
         "transitions": [from_stg(graph) for graph in result.transitions],
     }
-    if result.formalism_type is not None:
-        output["formalism_type"] = result.formalism_type
+    if result.formalism is not None:
+        output["formalism"] = result.formalism
     return output
 
 
@@ -116,13 +116,13 @@ def build_particle(definition: dict) -> Particle:
 
 
 def build_result(definition: dict) -> Result:
-    formalism_type = definition.get("formalism_type")
+    formalism = definition.get("formalism")
     transitions = [
         build_stg(graph_def) for graph_def in definition["transitions"]
     ]
     return Result(
         transitions=transitions,
-        formalism_type=formalism_type,
+        formalism=formalism,
     )
 
 

--- a/src/qrules/settings.py
+++ b/src/qrules/settings.py
@@ -94,7 +94,7 @@ class InteractionType(Enum):
 
 
 def create_interaction_settings(  # pylint: disable=too-many-locals,too-many-arguments
-    formalism_type: str,
+    formalism: str,
     particle_db: ParticleCollection,
     nbody_topology: bool = False,
     mass_conservation_factor: Optional[float] = 3.0,
@@ -121,7 +121,7 @@ def create_interaction_settings(  # pylint: disable=too-many-locals,too-many-arg
     spin_magnitude_domain = __get_spin_magnitudes(
         nbody_topology, max_spin_magnitude
     )
-    if "helicity" in formalism_type:
+    if "helicity" in formalism:
         formalism_node_settings.conservation_rules = {
             spin_magnitude_conservation,
             helicity_conservation,
@@ -130,7 +130,7 @@ def create_interaction_settings(  # pylint: disable=too-many-locals,too-many-arg
             NodeQN.l_magnitude: angular_momentum_domain,
             NodeQN.s_magnitude: spin_magnitude_domain,
         }
-    elif formalism_type == "canonical":
+    elif formalism == "canonical":
         formalism_node_settings.conservation_rules = {
             spin_magnitude_conservation
         }
@@ -145,7 +145,7 @@ def create_interaction_settings(  # pylint: disable=too-many-locals,too-many-arg
             NodeQN.s_magnitude: spin_magnitude_domain,
             NodeQN.s_projection: __extend_negative(spin_magnitude_domain),
         }
-    if formalism_type == "canonical-helicity":
+    if formalism == "canonical-helicity":
         formalism_node_settings.conservation_rules.update(
             {
                 clebsch_gordan_helicity_to_canonical,
@@ -193,7 +193,7 @@ def create_interaction_settings(  # pylint: disable=too-many-locals,too-many-arg
             c_parity_conservation,
         }
     )
-    if "helicity" in formalism_type:
+    if "helicity" in formalism:
         em_node_settings.conservation_rules.add(parity_conservation_helicity)
         em_node_settings.qn_domains.update({NodeQN.parity_prefactor: [-1, 1]})
 

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -145,7 +145,7 @@ class Result:
     transitions: List[StateTransitionGraph[ParticleWithSpin]] = attr.ib(
         factory=list
     )
-    formalism_type: Optional[str] = attr.ib(default=None)
+    formalism: Optional[str] = attr.ib(default=None)
 
     def get_initial_state(self) -> List[Particle]:
         graph = self.__get_first_graph()
@@ -260,7 +260,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         interaction_type_settings: Dict[
             InteractionType, Tuple[EdgeSettings, NodeSettings]
         ] = None,
-        formalism_type: str = "helicity",
+        formalism: str = "helicity",
         topology_building: str = "isobar",
         number_of_threads: Optional[int] = None,
         solving_mode: SolvingMode = SolvingMode.FAST,
@@ -271,17 +271,17 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
     ) -> None:
         if interaction_type_settings is None:
             interaction_type_settings = {}
-        allowed_formalism_types = [
+        allowed_formalisms = [
             "helicity",
             "canonical-helicity",
             "canonical",
         ]
-        if formalism_type not in allowed_formalism_types:
+        if formalism not in allowed_formalisms:
             raise NotImplementedError(
-                f"Formalism type {formalism_type} not implemented."
-                f" Use {allowed_formalism_types} instead."
+                f'Formalism "{formalism}" not implemented.'
+                f" Use one of {allowed_formalisms} instead."
             )
-        self.__formalism_type = str(formalism_type)
+        self.__formalism = str(formalism)
         self.__particles = ParticleCollection()
         if particle_db is not None:
             self.__particles = particle_db
@@ -306,14 +306,14 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         ]
         self.filter_remove_qns: Set[Type[NodeQuantumNumber]] = set()
         self.filter_ignore_qns: Set[Type[NodeQuantumNumber]] = set()
-        if formalism_type == "helicity":
+        if formalism == "helicity":
             self.filter_remove_qns = {
                 NodeQuantumNumbers.l_magnitude,
                 NodeQuantumNumbers.l_projection,
                 NodeQuantumNumbers.s_magnitude,
                 NodeQuantumNumbers.s_projection,
             }
-        if "helicity" in formalism_type:
+        if "helicity" in formalism:
             self.filter_ignore_qns = {NodeQuantumNumbers.parity_prefactor}
         use_nbody_topology = False
         topology_building = topology_building.lower()
@@ -334,7 +334,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
 
         if not self.interaction_type_settings:
             self.interaction_type_settings = create_interaction_settings(
-                formalism_type,
+                formalism,
                 particle_db=self.__particles,
                 nbody_topology=use_nbody_topology,
                 mass_conservation_factor=mass_conservation_factor,
@@ -374,8 +374,8 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             ]
 
     @property
-    def formalism_type(self) -> str:
-        return self.__formalism_type
+    def formalism(self) -> str:
+        return self.__formalism
 
     def add_final_state_grouping(
         self, fs_group: List[Union[str, List[str]]]
@@ -655,7 +655,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         match_external_edges(final_solutions)
         return Result(
             final_solutions,
-            formalism_type=self.formalism_type,
+            formalism=self.formalism,
         )
 
     def _solve(

--- a/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
+++ b/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
@@ -5,18 +5,18 @@ from qrules import InteractionType, StateTransitionManager
 
 
 @pytest.mark.parametrize(
-    ("formalism_type", "n_solutions"),
+    ("formalism", "n_solutions"),
     [
         ("helicity", 14),
         ("canonical-helicity", 28),  # two different LS couplings 2*14 = 28
     ],
 )
-def test_simple(formalism_type, n_solutions, particle_database):
+def test_simple(formalism, n_solutions, particle_database):
     result = qrules.generate_transitions(
         initial_state=[("Y(4260)", [-1, +1])],
         final_state=["D*(2007)0", "D*(2007)~0"],
         particle_db=particle_database,
-        formalism_type=formalism_type,
+        formalism=formalism,
         allowed_interaction_types="strong",
         number_of_threads=1,
     )
@@ -25,19 +25,19 @@ def test_simple(formalism_type, n_solutions, particle_database):
 
 @pytest.mark.slow()
 @pytest.mark.parametrize(
-    ("formalism_type", "n_solutions"),
+    ("formalism", "n_solutions"),
     [
         ("helicity", 14),
         ("canonical-helicity", 28),  # two different LS couplings 2*14 = 28
     ],
 )
-def test_full(formalism_type, n_solutions, particle_database):
+def test_full(formalism, n_solutions, particle_database):
     stm = StateTransitionManager(
         initial_state=[("Y(4260)", [-1, +1])],
         final_state=["D0", "D~0", "pi0", "pi0"],
         particle_db=particle_database,
         allowed_intermediate_particles=["D*"],
-        formalism_type=formalism_type,
+        formalism=formalism,
         number_of_threads=1,
     )
     stm.set_allowed_interaction_types([InteractionType.STRONG])

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,11 +12,11 @@ logging.basicConfig(level=logging.ERROR)
 
 @pytest.fixture(scope="session", params=["canonical-helicity", "helicity"])
 def result(request: SubRequest) -> Result:
-    formalism_type: str = request.param
+    formalism: str = request.param
     return qrules.generate_transitions(
         initial_state=[("J/psi(1S)", [-1, 1])],
         final_state=["gamma", "pi0", "pi0"],
         allowed_intermediate_particles=["f(0)(980)", "f(0)(1500)"],
         allowed_interaction_types="strong only",
-        formalism_type=formalism_type,
+        formalism=formalism,
     )

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -33,16 +33,16 @@ def test_create_domains(particle_database: ParticleCollection):
 @pytest.mark.parametrize("interaction_type", list(InteractionType))
 @pytest.mark.parametrize("nbody_topology", [False, True])
 @pytest.mark.parametrize(
-    "formalism_type", ["canonical", "canonical-helicity", "helicity"]
+    "formalism", ["canonical", "canonical-helicity", "helicity"]
 )
 def test_create_interaction_settings(
     particle_database: ParticleCollection,
     interaction_type: InteractionType,
     nbody_topology: bool,
-    formalism_type: str,
+    formalism: str,
 ):
     settings = create_interaction_settings(
-        formalism_type,
+        formalism,
         particle_db=particle_database,
         nbody_topology=nbody_topology,
     )
@@ -75,20 +75,17 @@ def test_create_interaction_settings(
         "l_magnitude": _int_domain(0, 2),
         "s_magnitude": _halves_domain(0, 2),
     }
-    if "canonical" in formalism_type:
+    if "canonical" in formalism:
         expected["l_projection"] = [-2, -1, 0, 1, 2]
         expected["s_projection"] = _halves_domain(-2, 2)
-    if formalism_type == "canonical-helicity":
+    if formalism == "canonical-helicity":
         expected["l_projection"] = [0]
-    if (
-        "helicity" in formalism_type
-        and interaction_type != InteractionType.WEAK
-    ):
+    if "helicity" in formalism and interaction_type != InteractionType.WEAK:
         expected["parity_prefactor"] = [-1, 1]
     if nbody_topology:
         expected["l_magnitude"] = [0]
         expected["s_magnitude"] = [0]
-    if nbody_topology and formalism_type != "helicity":
+    if nbody_topology and formalism != "helicity":
         expected["l_projection"] = [0]
         expected["s_projection"] = [0]
 

--- a/tests/unit/test_system_control.py
+++ b/tests/unit/test_system_control.py
@@ -101,7 +101,7 @@ def test_external_edge_initialization(
         initial_state,
         final_state,
         particle_database,
-        formalism_type="helicity",
+        formalism="helicity",
         number_of_threads=1,
     )
 
@@ -365,7 +365,7 @@ def test_edge_swap(particle_database, initial_state, final_state):
         initial_state,
         final_state,
         particle_database,
-        formalism_type="helicity",
+        formalism="helicity",
         number_of_threads=1,
     )
     stm.set_allowed_interaction_types([InteractionType.STRONG])
@@ -411,7 +411,7 @@ def test_match_external_edges(particle_database, initial_state, final_state):
         initial_state,
         final_state,
         particle_database,
-        formalism_type="helicity",
+        formalism="helicity",
         number_of_threads=1,
     )
 
@@ -493,7 +493,7 @@ def test_external_edge_identical_particle_combinatorics(
         initial_state,
         final_state,
         particle_database,
-        formalism_type="helicity",
+        formalism="helicity",
         number_of_threads=1,
     )
     stm.set_allowed_interaction_types([InteractionType.STRONG])


### PR DESCRIPTION
Use
```python
result = qrules.generate_transitions(
    ....
    formalism="canonical-helicity",
)
```
instead of

```python
result = qrules.generate_transitions(
    ....
    formalism_type="canonical-helicity",
)
```