### PR TITLE
refactor: use canonical-helicity by default

### DIFF
--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -283,7 +283,7 @@ def generate_transitions(  # pylint: disable=too-many-arguments
     final_state: Sequence[StateDefinition],
     allowed_intermediate_particles: Optional[List[str]] = None,
     allowed_interaction_types: Optional[Union[str, List[str]]] = None,
-    formalism: str = "helicity",
+    formalism: str = "canonical-helicity",
     particle_db: Optional[ParticleCollection] = None,
     mass_conservation_factor: Optional[float] = 3.0,
     max_angular_momentum: int = 2,

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -34,6 +34,7 @@ def test_number_of_solutions(
         allowed_interaction_types="strong and EM",
         allowed_intermediate_particles=allowed_intermediate_particles,
         number_of_threads=1,
+        formalism="helicity",
     )
     assert len(result.transitions) == number_of_solutions
     assert result.get_intermediate_particles().names == set(
@@ -49,6 +50,7 @@ def test_id_to_particle_mappings(particle_database):
         allowed_interaction_types="strong",
         allowed_intermediate_particles=["f(0)(980)"],
         number_of_threads=1,
+        formalism="helicity",
     )
     assert len(result.transitions) == 4
     iter_solutions = iter(result.transitions)


### PR DESCRIPTION
Canonical is the most complete set of solutions. The idea is to do the formalism filtering later on, in AmpForm (see #12).