### PR TITLE
feat: implement Particle ordering

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -111,6 +111,7 @@
         "arange",
         "asdict",
         "asdot",
+        "astuple",
         "cano",
         "celltoolbar",
         "codacy",

--- a/src/qrules/particle.py
+++ b/src/qrules/particle.py
@@ -194,6 +194,13 @@ class Particle:  # pylint: disable=too-many-instance-attributes
                 ")"
             )
 
+    @property
+    def name_root(self) -> str:
+        name_root = self.name
+        name_root = re.sub(r"\(.+\)", "", name_root)
+        name_root = re.sub(r"[\*\+\-~\d']", "", name_root)
+        return name_root
+
     def __neg__(self) -> "Particle":
         return create_antiparticle(self)
 

--- a/src/qrules/particle.py
+++ b/src/qrules/particle.py
@@ -22,8 +22,8 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
+    List,
     Optional,
-    Set,
     SupportsFloat,
     Tuple,
     Union,
@@ -418,8 +418,8 @@ class ParticleCollection(abc.MutableSet):
             self.add(particle)
 
     @property
-    def names(self) -> Set[str]:
-        return set(self.__particles)
+    def names(self) -> List[str]:
+        return [p.name for p in sorted(self)]
 
 
 def create_particle(  # pylint: disable=too-many-arguments,too-many-locals

--- a/src/qrules/particle.py
+++ b/src/qrules/particle.py
@@ -89,6 +89,11 @@ class Spin:
     def __float__(self) -> float:
         return self.magnitude
 
+    def __gt__(self, other: Any) -> bool:
+        if isinstance(other, Spin):
+            return attr.astuple(self) > attr.astuple(other)
+        return self.magnitude > other
+
     def __neg__(self) -> "Spin":
         return Spin(self.magnitude, -self.projection)
 

--- a/src/qrules/particle.py
+++ b/src/qrules/particle.py
@@ -112,7 +112,7 @@ def _to_spin(value: Union[Spin, Tuple[float, float]]) -> Spin:
     return value
 
 
-@attr.s(frozen=True, repr=True, kw_only=True)
+@attr.s(frozen=True, order=False, repr=True, kw_only=True)
 class Particle:  # pylint: disable=too-many-instance-attributes
     """Immutable container of data defining a physical particle.
 
@@ -200,6 +200,23 @@ class Particle:  # pylint: disable=too-many-instance-attributes
         name_root = re.sub(r"\(.+\)", "", name_root)
         name_root = re.sub(r"[\*\+\-~\d']", "", name_root)
         return name_root
+
+    def __gt__(self, other: Any) -> bool:
+        if isinstance(other, Particle):
+
+            def sorting_key(particle: Particle) -> tuple:
+                name_root = particle.name_root
+                return (
+                    name_root[0].lower(),
+                    name_root,
+                    particle.mass,
+                    particle.charge,
+                )
+
+            return sorting_key(self) > sorting_key(other)
+        raise NotImplementedError(
+            f"Cannot compare {self.__class__.__name__} with {other.__class__.__name__}"
+        )
 
     def __neg__(self) -> "Particle":
         return create_antiparticle(self)

--- a/src/qrules/particle.py
+++ b/src/qrules/particle.py
@@ -14,6 +14,7 @@ import logging
 import re
 from collections import abc
 from difflib import get_close_matches
+from functools import total_ordering
 from math import copysign
 from typing import (
     Any,
@@ -50,6 +51,7 @@ def _to_float(value: SupportsFloat) -> float:
     return float_value
 
 
+@total_ordering
 @attr.s(frozen=True, eq=False, hash=True)
 class Spin:
     """Safe, immutable data container for spin **with projection**."""
@@ -117,6 +119,7 @@ def _to_spin(value: Union[Spin, Tuple[float, float]]) -> Spin:
     return value
 
 
+@total_ordering
 @attr.s(frozen=True, order=False, repr=True, kw_only=True)
 class Particle:  # pylint: disable=too-many-instance-attributes
     """Immutable container of data defining a physical particle.

--- a/src/qrules/quantum_numbers.py
+++ b/src/qrules/quantum_numbers.py
@@ -34,6 +34,8 @@ class Parity:
         return self.value == other
 
     def __gt__(self, other: Any) -> bool:
+        if other is None:
+            return True
         return self.value > int(other)
 
     def __int__(self) -> int:

--- a/tests/channels/test_d0_to_ks_kp_km.py
+++ b/tests/channels/test_d0_to_ks_kp_km.py
@@ -13,10 +13,10 @@ def test_script():
         number_of_threads=1,
     )
     assert len(result.transitions) == 5
-    assert result.get_intermediate_particles().names == {
-        "a(0)(980)+",
+    assert result.get_intermediate_particles().names == [
         "a(0)(980)-",
         "a(0)(980)0",
+        "a(0)(980)+",
         "a(2)(1320)-",
         "phi(1020)",
-    }
+    ]

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -14,8 +14,8 @@ from qrules.combinatorics import _create_edge_id_particle_mapping
         (
             [
                 "f(0)(980)",
-                "f(0)(1500)",
                 "f(2)(1270)",
+                "f(0)(1500)",
                 "f(2)(1950)",
                 "omega(782)",
             ],
@@ -37,8 +37,9 @@ def test_number_of_solutions(
         formalism="helicity",
     )
     assert len(result.transitions) == number_of_solutions
-    assert result.get_intermediate_particles().names == set(
-        allowed_intermediate_particles
+    assert (
+        result.get_intermediate_particles().names
+        == allowed_intermediate_particles
     )
 
 

--- a/tests/unit/test_particle.py
+++ b/tests/unit/test_particle.py
@@ -273,10 +273,10 @@ class TestParticleCollection:
             and p.spin == 2
             and p.strangeness == 1
         )
-        assert filtered_result.names == {
+        assert filtered_result.names == [
             "K(2)(1820)0",
             "K(2)(1820)+",
-        }
+        ]
 
     def test_find(self, particle_database: ParticleCollection):
         f2_1950 = particle_database.find(9050225)

--- a/tests/unit/test_particle.py
+++ b/tests/unit/test_particle.py
@@ -98,6 +98,26 @@ class TestParticle:
         assert particle.name != different_labels.name
         assert particle.pid != different_labels.pid
 
+    @pytest.mark.parametrize(
+        ("name1", "name2"),
+        [
+            # by name
+            ("pi0", "a(0)(980)-"),
+            # by mass
+            ("pi+", "pi-"),
+            ("pi-", "pi0"),
+            ("pi+", "pi0"),
+            ("K0", "K+"),
+            # by charge
+            ("a(0)(980)+", "a(0)(980)-"),
+            ("a(0)(980)+", "a(0)(980)0"),
+            ("a(0)(980)0", "a(0)(980)-"),
+        ],
+    )
+    def test_gt(self, name1, name2, particle_database: ParticleCollection):
+        pdg = particle_database
+        assert pdg[name1] > pdg[name2]
+
     def test_name_root(self, particle_database: ParticleCollection):
         name_roots = {p.name_root for p in particle_database}
         assert name_roots == {

--- a/tests/unit/test_particle.py
+++ b/tests/unit/test_particle.py
@@ -338,6 +338,17 @@ class TestSpin:
             spin2,
         }
 
+    @pytest.mark.parametrize(
+        ("spin1", "spin2"),
+        [
+            (Spin(1, 0), Spin(0, 0)),
+            (Spin(1, 1), Spin(1, 0)),
+            (Spin(1, +1), Spin(1, -1)),
+        ],
+    )
+    def test_gt(self, spin1: Spin, spin2: Spin):
+        assert spin1 > spin2
+
     def test_neg(self):
         isospin = Spin(1.5, -0.5)
         flipped_spin = -isospin

--- a/tests/unit/test_particle.py
+++ b/tests/unit/test_particle.py
@@ -98,6 +98,44 @@ class TestParticle:
         assert particle.name != different_labels.name
         assert particle.pid != different_labels.pid
 
+    def test_name_root(self, particle_database: ParticleCollection):
+        name_roots = {p.name_root for p in particle_database}
+        assert name_roots == {
+            "a",
+            "B",
+            "b",
+            "chi",
+            "D",
+            "Delta",
+            "e",
+            "eta",
+            "f",
+            "g",
+            "gamma",
+            "h",
+            "J/psi",
+            "K",
+            "Lambda",
+            "mu",
+            "N",
+            "n",
+            "nu",
+            "Omega",
+            "omega",
+            "p",
+            "phi",
+            "pi",
+            "psi",
+            "rho",
+            "Sigma",
+            "tau",
+            "Upsilon",
+            "W",
+            "Xi",
+            "Y",
+            "Z",
+        }
+
     def test_neg(self, particle_database: ParticleCollection):
         pip = particle_database.find(211)
         pim = particle_database.find(-211)

--- a/tests/unit/test_particle.py
+++ b/tests/unit/test_particle.py
@@ -161,6 +161,21 @@ class TestParticle:
         pim = particle_database.find(-211)
         assert pip == -pim
 
+    def test_total_ordering(self, particle_database: ParticleCollection):
+        pdg = particle_database
+        assert [
+            particle.name
+            for particle in sorted(
+                pdg.filter(lambda p: p.name.startswith("f(0)"))
+            )
+        ] == [
+            "f(0)(500)",
+            "f(0)(980)",
+            "f(0)(1370)",
+            "f(0)(1500)",
+            "f(0)(1710)",
+        ]
+
 
 class TestParticleCollection:
     def test_init(self, particle_database: ParticleCollection):

--- a/tests/unit/test_quantum_numbers.py
+++ b/tests/unit/test_quantum_numbers.py
@@ -12,6 +12,7 @@ class TestParity:
         parity = Parity(+1)
         assert parity == +1
         assert int(parity) == +1
+        assert parity > None
 
     @typing.no_type_check  # https://github.com/python/mypy/issues/4610
     def test_comparison(self):

--- a/tests/unit/test_solving.py
+++ b/tests/unit/test_solving.py
@@ -5,4 +5,4 @@ from qrules import Result
 class TestResult:
     def test_get_intermediate_state_names(self, result: Result):
         intermediate_particles = result.get_intermediate_particles()
-        assert intermediate_particles.names == {"f(0)(1500)", "f(0)(980)"}
+        assert intermediate_particles.names == ["f(0)(980)", "f(0)(1500)"]


### PR DESCRIPTION
Allows sorting `Particle` instances. This is useful later on in #26, when `StateTransition`s are meant to become frozen and sortable.

Note that `ParticleCollection.names` now returns a **`list`**, sorted using the [`total_ordering`](https://docs.python.org/3.9/library/functools.html#functools.total_ordering) of `Particle`.