### PR TITLE
fix: allow rendering iterables with graphviz

### DIFF
--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -155,7 +155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## {class}`.StateTransitionGraph`s"
+    "## {class}`.StateTransition`s"
    ]
   },
   {

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -136,7 +136,7 @@ def asdot(
         )
     if isinstance(instance, (ReactionInfo, StateTransitionCollection)):
         instance = instance.to_graphs()
-    if isinstance(instance, abc.Sequence):
+    if isinstance(instance, abc.Iterable):
         return _dot.graph_list_to_dot(
             instance,
             render_node=render_node,

--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -3,7 +3,8 @@
 See :doc:`/usage/visualize` for more info.
 """
 
-from typing import Callable, Iterable, List, Optional, Sequence, Union
+from collections import abc
+from typing import Callable, Iterable, List, Optional, Union
 
 from qrules.particle import Particle, ParticleCollection, ParticleWithSpin
 from qrules.quantum_numbers import InteractionProperties, _to_fraction
@@ -36,7 +37,7 @@ def embed_dot(func: Callable) -> Callable:
 
 @embed_dot
 def graph_list_to_dot(
-    graphs: Sequence[StateTransitionGraph],
+    graphs: Iterable[StateTransitionGraph],
     *,
     render_node: bool,
     render_final_state_id: bool,
@@ -61,6 +62,8 @@ def graph_list_to_dot(
             )
         graphs = _get_particle_graphs(graphs)
     dot = ""
+    if not isinstance(graphs, abc.Sequence):
+        graphs = list(graphs)
     for i, graph in enumerate(reversed(graphs)):
         dot += __graph_to_dot_content(
             graph,


### PR DESCRIPTION
Allow converting an **iterable** (not just a sequence) to DOT. This enables rendering for instance the output of a `filter` as DOT:

```python
import graphviz
import qrules

reaction = qrules.generate_transitions(
    initial_state="J/psi(1S)",
    final_state=["K0", "Sigma+", "p~"],
    allowed_interaction_types="strong",
)
transitions = filter(
    lambda t: t.states[3].particle.mass > 1.75,
    reaction.transitions,
)
dot = qrules.io.asdot(transitions, collapse_graphs=True, render_final_state_id=False)
graphviz.Source(dot)
```

![image](https://user-images.githubusercontent.com/29308176/123068857-91781d00-d412-11eb-8937-9c136cecd1da.png)
