### PR TITLE
docs: add conservation rules page

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -160,6 +160,7 @@ sphinx-togglebutton==0.2.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.3.0
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-hep-pdgref==0.1.3
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -159,6 +159,7 @@ sphinx-togglebutton==0.2.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.3.0
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-hep-pdgref==0.1.3
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -159,6 +159,7 @@ sphinx-togglebutton==0.2.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.3.0
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-hep-pdgref==0.1.3
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -159,6 +159,7 @@ sphinx-togglebutton==0.2.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.3.0
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-hep-pdgref==0.1.3
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,7 @@ extensions = [
     "sphinx_thebe",
     "sphinx_togglebutton",
     "sphinxcontrib.bibtex",
+    "sphinxcontrib.hep.pdgref",
 ]
 exclude_patterns = [
     "**.ipynb_checkpoints",

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -251,6 +251,7 @@
     "usage/reaction\n",
     "usage/particle\n",
     "usage/visualize\n",
+    "usage/conservation\n",
     "```"
    ]
   }

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -66,15 +66,33 @@
     "from qrules.conservation_rules import (\n",
     "    SpinEdgeInput,\n",
     "    SpinNodeInput,\n",
+    "    parity_conservation,\n",
     "    spin_conservation,\n",
-    ")"
+    ")\n",
+    "from qrules.quantum_numbers import Parity"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Required functions"
+    "QRules generates {class}`.StateTransitionGraph`s, populates them with quantum numbers (edge properties being states and nodes properties being interaction), then uses the rules formulates in the {mod}`.conservation_rules` module to check whether the generated {class}`.StateTransitionGraph`s comply with these conservation rules.\n",
+    "\n",
+    "The {mod}`.conservation_rules` module can also be used separately. In this notebook, we will illustrate this by checking spin and parity conservation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parity conservation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See {func}`.parity_conservation`:"
    ]
   },
   {
@@ -83,25 +101,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "help(SpinEdgeInput.__init__)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "help(SpinNodeInput.__init__)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "help(spin_conservation)"
+    "parity_conservation(\n",
+    "    ingoing_edge_qns=[Parity(-1)],\n",
+    "    outgoing_edge_qns=[Parity(+1), Parity(+1)],\n",
+    "    l_magnitude=1,\n",
+    ")"
    ]
   },
   {

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -60,6 +60,7 @@
    },
    "outputs": [],
    "source": [
+    "import attr\n",
     "import graphviz\n",
     "\n",
     "import qrules\n",
@@ -294,6 +295,62 @@
    "metadata": {},
    "source": [
     "**<span style=\"color:red\">This should be `True`, no?</span>**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{rubric} Side note\n",
+    "\n",
+    ":::\n",
+    "\n",
+    "A {class}`.StateTransition` is frozen, so it is not possible to modify its {attr}`~.StateTransition.interactions` and {attr}`~.StateTransition.states`. The only way around this is to create a new instance with {func}`attr.evolve`.\n",
+    "\n",
+    "First, we get the instance (in this case one of the {class}`.InteractionProperties`) and substitute its {attr}`.InteractionProperties.l_magnitude`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_interaction = attr.evolve(transition.interactions[node_id], l_magnitude=2)\n",
+    "new_interaction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then again use {func}`attr.evolve` to substitute the {attr}`.StateTransition.interactions` of the original {class}`.StateTransition`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_interaction_dict = dict(transition.interactions)  # make mutable\n",
+    "new_interaction_dict[node_id] = new_interaction\n",
+    "new_transition = attr.evolve(transition, interactions=new_interaction_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dot = qrules.io.asdot(new_transition, render_node=True)\n",
+    "graphviz.Source(dot)"
    ]
   }
  ],

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -1,0 +1,287 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true,
+    "hideOutput": true,
+    "hidePrompt": true,
+    "jupyter": {
+     "source_hidden": true
+    },
+    "slideshow": {
+     "slide_type": "skip"
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "%config Completer.use_jedi = False\n",
+    "%config InlineBackend.figure_formats = ['svg']\n",
+    "import os\n",
+    "\n",
+    "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)\n",
+    "\n",
+    "# Install on Google Colab\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "from IPython import get_ipython\n",
+    "\n",
+    "install_packages = \"google.colab\" in str(get_ipython())\n",
+    "if install_packages:\n",
+    "    for package in [\"qrules[doc]\", \"graphviz\"]:\n",
+    "        subprocess.check_call(\n",
+    "            [sys.executable, \"-m\", \"pip\", \"install\", package]\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Conservation rules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import graphviz\n",
+    "\n",
+    "import qrules\n",
+    "from qrules.conservation_rules import (\n",
+    "    SpinEdgeInput,\n",
+    "    SpinNodeInput,\n",
+    "    spin_conservation,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Required functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(SpinEdgeInput.__init__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(SpinNodeInput.__init__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(spin_conservation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See [`tests/unit/conservation_rules/test_spin.py`](https://github.com/ComPWA/qrules/blob/ffa91f5308f59bd729b25d1584827ac61a56d2de/tests/unit/conservation_rules/test_spin.py)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### No spin and angular momentum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spin_conservation(\n",
+    "    ingoing_spins=[\n",
+    "        SpinEdgeInput(0, 0),\n",
+    "    ],\n",
+    "    outgoing_spins=[\n",
+    "        SpinEdgeInput(0, 0),\n",
+    "        SpinEdgeInput(0, 0),\n",
+    "    ],\n",
+    "    interaction_qns=SpinNodeInput(\n",
+    "        l_magnitude=0,  # false if 1\n",
+    "        l_projection=0,\n",
+    "        s_magnitude=0,\n",
+    "        s_projection=0,\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Non-zero example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spin_conservation(\n",
+    "    ingoing_spins=[\n",
+    "        SpinEdgeInput(1, 0),\n",
+    "    ],\n",
+    "    outgoing_spins=[\n",
+    "        SpinEdgeInput(1, +1),\n",
+    "        SpinEdgeInput(1, -1),\n",
+    "    ],\n",
+    "    interaction_qns=SpinNodeInput(\n",
+    "        l_magnitude=1,\n",
+    "        l_projection=0,\n",
+    "        s_magnitude=2,\n",
+    "        s_projection=0,\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example with a `StateTransition`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reaction = qrules.generate_transitions(\n",
+    "    initial_state=\"J/psi(1S)\",\n",
+    "    final_state=[\"K0\", \"Sigma+\", \"p~\"],\n",
+    "    allowed_interaction_types=\"strong\",\n",
+    "    formalism=\"canonical\",  # \"canonical-helicity\"\n",
+    ")\n",
+    "transition = reaction.transitions[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dot = qrules.io.asdot(transition, render_node=True)\n",
+    "display(graphviz.Source(dot))\n",
+    "\n",
+    "dot = qrules.io.asdot(\n",
+    "    transition.topology,\n",
+    "    render_node=True,\n",
+    "    render_resonance_id=True,\n",
+    "    render_initial_state_id=True,\n",
+    ")\n",
+    "display(graphviz.Source(dot))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "incoming_state = transition.states[-1]\n",
+    "outgoing_state1 = transition.states[0]\n",
+    "outgoing_state2 = transition.states[3]\n",
+    "interaction = transition.interactions[0]\n",
+    "\n",
+    "spin_conservation(\n",
+    "    ingoing_spins=[\n",
+    "        SpinEdgeInput(\n",
+    "            spin_magnitude=incoming_state.particle.spin,\n",
+    "            spin_projection=incoming_state.spin_projection,\n",
+    "        )\n",
+    "    ],\n",
+    "    outgoing_spins=[\n",
+    "        SpinEdgeInput(\n",
+    "            spin_magnitude=outgoing_state1.particle.spin,\n",
+    "            spin_projection=outgoing_state1.spin_projection,\n",
+    "        ),\n",
+    "        SpinEdgeInput(\n",
+    "            spin_magnitude=outgoing_state2.particle.spin,\n",
+    "            spin_projection=outgoing_state2.spin_projection,\n",
+    "        ),\n",
+    "    ],\n",
+    "    interaction_qns=interaction,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**<span style=\"color:red\">This should be `True`, no?</span>**"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -54,7 +54,9 @@
     "jupyter": {
      "source_hidden": true
     },
-    "tags": []
+    "tags": [
+     "hide-cell"
+    ]
    },
    "outputs": [],
    "source": [
@@ -106,14 +108,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Examples"
+    "## Spin conservation"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See [`tests/unit/conservation_rules/test_spin.py`](https://github.com/ComPWA/qrules/blob/ffa91f5308f59bd729b25d1584827ac61a56d2de/tests/unit/conservation_rules/test_spin.py)."
+    "See {func}`.spin_conservation` and [`tests/unit/conservation_rules/test_spin.py`](https://github.com/ComPWA/qrules/blob/ffa91f5308f59bd729b25d1584827ac61a56d2de/tests/unit/conservation_rules/test_spin.py)."
    ]
   },
   {
@@ -186,6 +188,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, generate some {class}`.StateTransition`s with {func}`.generate_transitions`, then select one of them:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -201,13 +210,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, have a look at the edge and node properties, and use the underlying {class}`.Topology` to extract one of the node {class}`.InteractionProperties` with the surrounding states (these are {obj}`tuple`s of a {class}`.Particle` and a {obj}`float` spin projection)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
     "jupyter": {
      "source_hidden": true
     },
-    "tags": []
+    "tags": [
+     "hide-input"
+    ]
    },
    "outputs": [],
    "source": [
@@ -224,15 +242,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We select node $(0)$, which has incoming state ID $-1$ and outgoing state IDs $0$ and $3$:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "incoming_state = transition.states[-1]\n",
-    "outgoing_state1 = transition.states[0]\n",
-    "outgoing_state2 = transition.states[3]\n",
-    "interaction = transition.interactions[0]\n",
+    "topology = transition.topology\n",
+    "node_id = 0\n",
+    "in_id, *_ = topology.get_edge_ids_ingoing_to_node(node_id)\n",
+    "out_id1, out_id2, *_ = topology.get_edge_ids_outgoing_from_node(node_id)\n",
+    "\n",
+    "incoming_state = transition.states[in_id]\n",
+    "outgoing_state1 = transition.states[out_id1]\n",
+    "outgoing_state2 = transition.states[out_id2]\n",
+    "interaction = transition.interactions[node_id]\n",
     "\n",
     "spin_conservation(\n",
     "    ingoing_spins=[\n",

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -69,6 +69,7 @@
     "    SpinNodeInput,\n",
     "    parity_conservation,\n",
     "    spin_conservation,\n",
+    "    spin_magnitude_conservation,\n",
     ")\n",
     "from qrules.quantum_numbers import Parity"
    ]
@@ -77,7 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "QRules generates {class}`.StateTransitionGraph`s, populates them with quantum numbers (edge properties being states and nodes properties being interaction), then uses the rules formulates in the {mod}`.conservation_rules` module to check whether the generated {class}`.StateTransitionGraph`s comply with these conservation rules.\n",
+    "QRules generates {class}`.StateTransitionGraph`s, populates them with quantum numbers (edge properties representing states and nodes properties representing interactions), then checks whether the generated {class}`.StateTransitionGraph`s comply with the rules formulated in the {mod}`.conservation_rules` module.\n",
     "\n",
     "The {mod}`.conservation_rules` module can also be used separately. In this notebook, we will illustrate this by checking spin and parity conservation."
    ]
@@ -124,7 +125,9 @@
     "\n",
     "{func}`.spin_conservation`, [`tests/unit/conservation_rules/test_spin.py`](https://github.com/ComPWA/qrules/blob/ffa91f5308f59bd729b25d1584827ac61a56d2de/tests/unit/conservation_rules/test_spin.py), {pdg-review}`Quark Model`, and [these lecture notes](http://www.curtismeyer.com/material/lecture.pdf) by Curtis Meyer.\n",
     "\n",
-    ":::"
+    ":::\n",
+    "\n",
+    "{func}`.spin_conservation` checks whether spin magnitude and spin projections are conserved. In addition, it checks whether the Clebsch-Gordan coefficients are non-zero, meaning that the coupled spins on the interaction nodes are valid as well."
    ]
   },
   {
@@ -193,7 +196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example with a `StateTransition`"
+    "## Example with a {class}`.StateTransition`"
    ]
   },
   {
@@ -213,7 +216,7 @@
     "    initial_state=\"J/psi(1S)\",\n",
     "    final_state=[\"K0\", \"Sigma+\", \"p~\"],\n",
     "    allowed_interaction_types=\"strong\",\n",
-    "    formalism=\"canonical\",  # \"canonical-helicity\"\n",
+    "    formalism=\"canonical\",\n",
     ")\n",
     "transition = reaction.transitions[0]"
    ]
@@ -273,6 +276,40 @@
     "outgoing_state2 = transition.states[out_id2]\n",
     "interaction = transition.interactions[node_id]\n",
     "\n",
+    "spin_magnitude_conservation(\n",
+    "    ingoing_spins=[\n",
+    "        SpinEdgeInput(\n",
+    "            spin_magnitude=incoming_state.particle.spin,\n",
+    "            spin_projection=incoming_state.spin_projection,\n",
+    "        )\n",
+    "    ],\n",
+    "    outgoing_spins=[\n",
+    "        SpinEdgeInput(\n",
+    "            spin_magnitude=outgoing_state1.particle.spin,\n",
+    "            spin_projection=outgoing_state1.spin_projection,\n",
+    "        ),\n",
+    "        SpinEdgeInput(\n",
+    "            spin_magnitude=outgoing_state2.particle.spin,\n",
+    "            spin_projection=outgoing_state2.spin_projection,\n",
+    "        ),\n",
+    "    ],\n",
+    "    interaction_qns=interaction,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Contrary to expectations, this transition does not conserve spin **projection** and therefore {func}`.spin_conservation` returns {obj}`False`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "spin_conservation(\n",
     "    ingoing_spins=[\n",
     "        SpinEdgeInput(\n",
@@ -298,18 +335,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**<span style=\"color:red\">This should be `True`, no?</span>**"
+    "The reason is that AmpForm formulates the {class}`~ampform.helicity.HelicityModel` with the helicity formalism first and then uses a transformation to get the model in the canonical basis (see {func}`~ampform.helicity.formulate_clebsch_gordan_coefficients`). The canonical basis does not conserve helicity (taken to be {attr}`.State.spin_projection`)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    ":::{rubric} Side note\n",
-    "\n",
-    ":::\n",
-    "\n",
-    "A {class}`.StateTransition` is frozen, so it is not possible to modify its {attr}`~.StateTransition.interactions` and {attr}`~.StateTransition.states`. The only way around this is to create a new instance with {func}`attr.evolve`.\n",
+    "### Modifying {class}`.StateTransition`s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When checking conservation rules, you may want to modify the properties on the {class}`.StateTransition`s. However, a {class}`.StateTransition` is frozen, so it is not possible to modify its {attr}`~.StateTransition.interactions` and {attr}`~.StateTransition.states`. The only way around this is to create a new instance with {func}`attr.evolve`.\n",
     "\n",
     "First, we get the instance (in this case one of the {class}`.InteractionProperties`) and substitute its {attr}`.InteractionProperties.l_magnitude`:"
    ]
@@ -349,7 +389,9 @@
     "jupyter": {
      "source_hidden": true
     },
-    "tags": []
+    "tags": [
+     "hide-input"
+    ]
    },
    "outputs": [],
    "source": [

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -120,7 +120,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See {func}`.spin_conservation` and [`tests/unit/conservation_rules/test_spin.py`](https://github.com/ComPWA/qrules/blob/ffa91f5308f59bd729b25d1584827ac61a56d2de/tests/unit/conservation_rules/test_spin.py)."
+    ":::{seealso}\n",
+    "\n",
+    "{func}`.spin_conservation`, [`tests/unit/conservation_rules/test_spin.py`](https://github.com/ComPWA/qrules/blob/ffa91f5308f59bd729b25d1584827ac61a56d2de/tests/unit/conservation_rules/test_spin.py), {pdg-review}`Quark Model`, and [these lecture notes](http://www.curtismeyer.com/material/lecture.pdf) by Curtis Meyer.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ doc =
     sphinx-thebe
     sphinx-togglebutton
     sphinxcontrib-bibtex >= 2
+    sphinxcontrib-hep-pdgref
     sphobjinv
 test =
     ipython

--- a/src/qrules/conservation_rules.py
+++ b/src/qrules/conservation_rules.py
@@ -44,6 +44,8 @@ The module is therefore strongly typed (both
 for the reader of the code and for type checking with :doc:`mypy
 <mypy:index>`). An example is `.HelicityParityEdgeInput`, which has been
 defined to provide type checks on `.parity_conservation_helicity`.
+
+.. seealso:: :doc:`/usage/conservation`
 """
 
 from copy import deepcopy


### PR DESCRIPTION
Describe how to use the [`conservation_rules`](https://qrules.readthedocs.io/en/0.9.1/api/qrules.conservation_rules.html) module separately.

A preview _with cell output_ can be viewed here:
https://qrules.readthedocs.io/en/doc-conservation-rules/usage/conservation.html
(until this PR is closed).