### PR TITLE
ci!: switch to pre-commit.ci where possible

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -5,11 +5,11 @@
 #    pip-compile --extra=dev --no-annotate --output-file=.constraints/py3.6.txt
 #
 alabaster==0.7.12
-anyio==3.2.1
+anyio==3.3.0
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==20.1.0
-astroid==2.6.2
+astroid==2.6.5
 async-generator==1.10
 attrs==20.3.0
 babel==2.9.1
@@ -71,7 +71,7 @@ jupyter-cache==0.4.2
 jupyter-client==6.1.12
 jupyter-console==6.4.0
 jupyter-core==4.7.1
-jupyter-server==1.9.0
+jupyter-server==1.10.1
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
 jupyterlab==3.0.16
@@ -108,7 +108,7 @@ pep8-naming==0.12.0
 pexpect==4.8.0
 pickleshare==0.7.5
 pip-tools==6.2.0
-platformdirs==2.0.2
+platformdirs==2.1.0
 pluggy==0.13.1
 pre-commit==2.13.0
 prometheus-client==0.11.0
@@ -124,7 +124,7 @@ pydocstyle==6.1.1
 pydot==1.4.2
 pyflakes==2.3.1
 pygments==2.9.0
-pylint==2.9.3
+pylint==2.9.5
 pyparsing==2.4.7
 pyrsistent==0.18.0
 pytest==6.2.4
@@ -152,7 +152,7 @@ snowballstemmer==2.1.0
 soupsieve==2.2.1
 sphinx==3.5.4
 sphinx-autobuild==2021.3.14
-sphinx-book-theme==0.1.0
+sphinx-book-theme==0.1.1
 sphinx-copybutton==0.4.0
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.8
@@ -169,7 +169,7 @@ sqlalchemy==1.3.24
 terminado==0.10.1
 testpath==0.5.0
 toml==0.10.2
-tomli==1.0.4
+tomli==1.1.0
 tornado==6.1
 tox==3.24.0
 tqdm==4.61.2

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -5,11 +5,11 @@
 #    pip-compile --extra=dev --no-annotate --output-file=.constraints/py3.7.txt
 #
 alabaster==0.7.12
-anyio==3.2.1
+anyio==3.3.0
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==20.1.0
-astroid==2.6.2
+astroid==2.6.5
 async-generator==1.10
 attrs==20.3.0
 babel==2.9.1
@@ -25,7 +25,7 @@ charset-normalizer==2.0.3
 click==8.0.1
 colorama==0.4.4
 coverage==5.5
-debugpy==1.3.0
+debugpy==1.4.1
 decorator==5.0.9
 defusedxml==0.7.1
 distlib==0.3.2
@@ -55,7 +55,7 @@ imagesize==1.2.0
 importlib-metadata==3.10.1
 importlib-resources==5.2.0
 iniconfig==1.1.1
-ipykernel==6.0.2
+ipykernel==6.0.3
 ipython==7.25.0
 ipython-genutils==0.2.0
 ipywidgets==7.6.3
@@ -69,7 +69,7 @@ jupyter-cache==0.4.2
 jupyter-client==6.1.12
 jupyter-console==6.4.0
 jupyter-core==4.7.1
-jupyter-server==1.9.0
+jupyter-server==1.10.1
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
 jupyterlab==3.0.16
@@ -107,7 +107,7 @@ pep8-naming==0.12.0
 pexpect==4.8.0
 pickleshare==0.7.5
 pip-tools==6.2.0
-platformdirs==2.0.2
+platformdirs==2.1.0
 pluggy==0.13.1
 pre-commit==2.13.0
 prometheus-client==0.11.0
@@ -123,7 +123,7 @@ pydocstyle==6.1.1
 pydot==1.4.2
 pyflakes==2.3.1
 pygments==2.9.0
-pylint==2.9.3
+pylint==2.9.5
 pyparsing==2.4.7
 pyrsistent==0.18.0
 pytest==6.2.4
@@ -151,7 +151,7 @@ snowballstemmer==2.1.0
 soupsieve==2.2.1
 sphinx==3.5.4
 sphinx-autobuild==2021.3.14
-sphinx-book-theme==0.1.0
+sphinx-book-theme==0.1.1
 sphinx-copybutton==0.4.0
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.8
@@ -168,7 +168,7 @@ sqlalchemy==1.3.24
 terminado==0.10.1
 testpath==0.5.0
 toml==0.10.2
-tomli==1.0.4
+tomli==1.1.0
 tornado==6.1
 tox==3.24.0
 tqdm==4.61.2

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -5,11 +5,11 @@
 #    pip-compile --extra=dev --no-annotate --output-file=.constraints/py3.8.txt
 #
 alabaster==0.7.12
-anyio==3.2.1
+anyio==3.3.0
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==20.1.0
-astroid==2.6.2
+astroid==2.6.5
 async-generator==1.10
 attrs==20.3.0
 babel==2.9.1
@@ -25,7 +25,7 @@ charset-normalizer==2.0.3
 click==8.0.1
 colorama==0.4.4
 coverage==5.5
-debugpy==1.3.0
+debugpy==1.4.1
 decorator==5.0.9
 defusedxml==0.7.1
 distlib==0.3.2
@@ -55,7 +55,7 @@ imagesize==1.2.0
 importlib-metadata==4.6.1
 importlib-resources==5.2.0
 iniconfig==1.1.1
-ipykernel==6.0.2
+ipykernel==6.0.3
 ipython==7.25.0
 ipython-genutils==0.2.0
 ipywidgets==7.6.3
@@ -69,7 +69,7 @@ jupyter-cache==0.4.2
 jupyter-client==6.1.12
 jupyter-console==6.4.0
 jupyter-core==4.7.1
-jupyter-server==1.9.0
+jupyter-server==1.10.1
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
 jupyterlab==3.0.16
@@ -107,7 +107,7 @@ pep8-naming==0.12.0
 pexpect==4.8.0
 pickleshare==0.7.5
 pip-tools==6.2.0
-platformdirs==2.0.2
+platformdirs==2.1.0
 pluggy==0.13.1
 pre-commit==2.13.0
 prometheus-client==0.11.0
@@ -123,7 +123,7 @@ pydocstyle==6.1.1
 pydot==1.4.2
 pyflakes==2.3.1
 pygments==2.9.0
-pylint==2.9.3
+pylint==2.9.5
 pyparsing==2.4.7
 pyrsistent==0.18.0
 pytest==6.2.4
@@ -151,7 +151,7 @@ snowballstemmer==2.1.0
 soupsieve==2.2.1
 sphinx==3.5.4
 sphinx-autobuild==2021.3.14
-sphinx-book-theme==0.1.0
+sphinx-book-theme==0.1.1
 sphinx-copybutton==0.4.0
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.8
@@ -168,7 +168,7 @@ sqlalchemy==1.3.24
 terminado==0.10.1
 testpath==0.5.0
 toml==0.10.2
-tomli==1.0.4
+tomli==1.1.0
 tornado==6.1
 tox==3.24.0
 tqdm==4.61.2

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -5,11 +5,11 @@
 #    pip-compile --extra=dev --no-annotate --output-file=.constraints/py3.9.txt
 #
 alabaster==0.7.12
-anyio==3.2.1
+anyio==3.3.0
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==20.1.0
-astroid==2.6.2
+astroid==2.6.5
 async-generator==1.10
 attrs==20.3.0
 babel==2.9.1
@@ -25,7 +25,7 @@ charset-normalizer==2.0.3
 click==8.0.1
 colorama==0.4.4
 coverage==5.5
-debugpy==1.3.0
+debugpy==1.4.1
 decorator==5.0.9
 defusedxml==0.7.1
 distlib==0.3.2
@@ -55,7 +55,7 @@ imagesize==1.2.0
 importlib-metadata==4.6.1
 importlib-resources==5.2.0
 iniconfig==1.1.1
-ipykernel==6.0.2
+ipykernel==6.0.3
 ipython==7.25.0
 ipython-genutils==0.2.0
 ipywidgets==7.6.3
@@ -69,7 +69,7 @@ jupyter-cache==0.4.2
 jupyter-client==6.1.12
 jupyter-console==6.4.0
 jupyter-core==4.7.1
-jupyter-server==1.9.0
+jupyter-server==1.10.1
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
 jupyterlab==3.0.16
@@ -107,7 +107,7 @@ pep8-naming==0.12.0
 pexpect==4.8.0
 pickleshare==0.7.5
 pip-tools==6.2.0
-platformdirs==2.0.2
+platformdirs==2.1.0
 pluggy==0.13.1
 pre-commit==2.13.0
 prometheus-client==0.11.0
@@ -123,7 +123,7 @@ pydocstyle==6.1.1
 pydot==1.4.2
 pyflakes==2.3.1
 pygments==2.9.0
-pylint==2.9.3
+pylint==2.9.5
 pyparsing==2.4.7
 pyrsistent==0.18.0
 pytest==6.2.4
@@ -151,7 +151,7 @@ snowballstemmer==2.1.0
 soupsieve==2.2.1
 sphinx==3.5.4
 sphinx-autobuild==2021.3.14
-sphinx-book-theme==0.1.0
+sphinx-book-theme==0.1.1
 sphinx-copybutton==0.4.0
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.8
@@ -168,7 +168,7 @@ sqlalchemy==1.3.24
 terminado==0.10.1
 testpath==0.5.0
 toml==0.10.2
-tomli==1.0.4
+tomli==1.1.0
 tornado==6.1
 tox==3.24.0
 tqdm==4.61.2

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -24,5 +24,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -c .constraints/py3.7.txt -e .[sty]
-      - name: Perform style checks
-        run: pre-commit run -a --color always
+      - name: Run non-local pre-commit hooks
+        run: |
+          pre-commit run flake8 -a --color always
+          pre-commit run mypy -a --color always
+          pre-commit run pylint -a --color always
+          pre-commit run pyright -a --color always

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -30,3 +30,7 @@ jobs:
           pre-commit run mypy -a --color always
           pre-commit run pylint -a --color always
           pre-commit run pyright -a --color always
+      - name: Run pre-commit hooks that don't work on pre-commit.ci
+        # cspell:ignore editorconfig
+        run: |
+          pre-commit run editorconfig-checker -a --color always

--- a/.github/workflows/ci-style.yml
+++ b/.github/workflows/ci-style.yml
@@ -29,8 +29,8 @@ jobs:
           pre-commit run flake8 -a --color always
           pre-commit run mypy -a --color always
           pre-commit run pylint -a --color always
-          pre-commit run pyright -a --color always
       - name: Run pre-commit hooks that don't work on pre-commit.ci
         # cspell:ignore editorconfig
         run: |
           pre-commit run editorconfig-checker -a --color always
+          pre-commit run pyright -a --color always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,8 @@ ci:
     - mypy
     - pylint
     - pyright
+    # hooks that don't work on pre-commit.ci
+    - editorconfig-checker
 
 repos:
   - repo: meta

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,11 @@ repos:
       - id: fix-nbformat-version
       - id: format-setup-cfg
 
+  - repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+      - id: black
+
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.10.0
     hooks:
@@ -69,6 +74,11 @@ repos:
             .*\.py
           )$
 
+  - repo: https://github.com/pycqa/isort
+    rev: 5.9.2
+    hooks:
+      - id: isort
+
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.28.1
     hooks:
@@ -95,6 +105,11 @@ repos:
       - id: prettier
         language_version: 12.18.2 # prettier does not specify node correctly
 
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.1.1
+    hooks:
+      - id: pydocstyle
+
   - repo: https://github.com/ComPWA/mirrors-pyright
     rev: v1.1.157
     hooks:
@@ -105,13 +120,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: black
-        name: black
-        entry: black
-        language: system
-        types:
-          - python
-
       - id: flake8
         name: flake8
         entry: flake8
@@ -119,23 +127,9 @@ repos:
         types:
           - python
 
-      - id: isort
-        name: isort
-        entry: isort
-        language: system
-        types:
-          - python
-
       - id: mypy
         name: mypy
         entry: mypy
-        language: system
-        types:
-          - python
-
-      - id: pydocstyle
-        name: pydocstyle
-        entry: pydocstyle
         language: system
         types:
           - python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,13 @@
+ci:
+  autoupdate_commit_msg: "ci: autoupdate pre-commit hooks"
+  autoupdate_schedule: quarterly # already done by requirements-cron.yml
+  skip:
+    # local hooks
+    - flake8
+    - mypy
+    - pylint
+    - pyright
+
 repos:
   - repo: meta
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,12 +70,12 @@ repos:
           )$
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.27.1
+    rev: v0.28.1
     hooks:
       - id: markdownlint
 
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.13.1
+    rev: 1.0.0
     hooks:
       - id: nbqa-black
         args: [--nbqa-mutate]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,9 @@ ci:
     - flake8
     - mypy
     - pylint
-    - pyright
     # hooks that don't work on pre-commit.ci
     - editorconfig-checker
+    - pyright
 
 repos:
   - repo: meta

--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,7 @@ passenv = HOME
 description =
     Perform all linting, formatting, and spelling checks
 setenv =
-    SKIP = mypy
+    SKIP = mypy, pyright
 allowlist_externals =
     mypy
     pre-commit


### PR DESCRIPTION
[pre-commit.ci](https://pre-commit.ci) is faster than GitHub Actions, so it would be better to switch to that. The only problem is that hooks like `pylint`, `mypy`, and even `flake8` require additional dependencies and we don't want to maintain a list of those in both `setup.cfg` (required for code editors that use those dependencies) as well as in `.pre-commit-config.yaml`. There are also hooks like `pyright` and `editorconfig-checker` that don't work well on pre-commit.ci.

This PR makes all hooks that don't require additional dependencies (like `black` and `isort`) ['non-local'](https://pre-commit.com/#repository-local-hooks). This also works better with source control in VSCode.
Caveat: pinned requirements might diverge from the versions of the hooks.

This PR is a bit experimental -- we'll have to see how well this works out before it is implemented in AmpForm etc.

Another potential problem is that (afaics), pre-commit.ci cannot switch off [autoupdate](https://pre-commit.ci/#configuration) (at most set to `quarterly`). It is (for now) better to upgrade the hooks along with the requirement pinning though.