### PR TITLE
style: decrease code line width in notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,10 +100,15 @@ repos:
     rev: 1.0.0
     hooks:
       - id: nbqa-black
+        args:
+          # smaller line length for sphinx-book-theme
+          - --line-length=73
       - id: nbqa-flake8
         args:
           - --extend-ignore=E402,F821
       - id: nbqa-isort
+        args:
+          - --line-length=73
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,11 +100,10 @@ repos:
     rev: 1.0.0
     hooks:
       - id: nbqa-black
-        args: [--nbqa-mutate]
       - id: nbqa-flake8
-        args: ["--extend-ignore=E402,F821"]
+        args:
+          - --extend-ignore=E402,F821
       - id: nbqa-isort
-        args: [--nbqa-mutate]
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.5.0

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -360,7 +360,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_interaction = attr.evolve(transition.interactions[node_id], l_magnitude=2)\n",
+    "new_interaction = attr.evolve(\n",
+    "    transition.interactions[node_id], l_magnitude=2\n",
+    ")\n",
     "new_interaction"
    ]
   },
@@ -379,7 +381,9 @@
    "source": [
     "new_interaction_dict = dict(transition.interactions)  # make mutable\n",
     "new_interaction_dict[node_id] = new_interaction\n",
-    "new_transition = attr.evolve(transition, interactions=new_interaction_dict)"
+    "new_transition = attr.evolve(\n",
+    "    transition, interactions=new_interaction_dict\n",
+    ")"
    ]
   },
   {

--- a/docs/usage/particle.ipynb
+++ b/docs/usage/particle.ipynb
@@ -167,7 +167,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "particle_db.filter(lambda p: p.name.startswith(\"pi\") and len(p.name) == 3)"
+    "particle_db.filter(\n",
+    "    lambda p: p.name.startswith(\"pi\") and len(p.name) == 3\n",
+    ")"
    ]
   },
   {
@@ -312,7 +314,9 @@
     "for energy_mev in energies_mev:\n",
     "    energy_gev = energy_mev / 1e3\n",
     "    new_particle = create_particle(\n",
-    "        template_particle, name=f\"EpEm ({energy_mev} MeV)\", mass=energy_gev\n",
+    "        template_particle,\n",
+    "        name=f\"EpEm ({energy_mev} MeV)\",\n",
+    "        mass=energy_gev,\n",
     "    )\n",
     "    particle_db.add(new_particle)\n",
     "len(particle_db)"

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -330,7 +330,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stm.set_allowed_interaction_types([InteractionType.STRONG, InteractionType.EM])\n",
+    "stm.set_allowed_interaction_types(\n",
+    "    [InteractionType.STRONG, InteractionType.EM]\n",
+    ")\n",
     "problem_sets = stm.create_problem_sets()\n",
     "reaction = stm.find_solutions(problem_sets)\n",
     "\n",

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -81,7 +81,10 @@
     "import graphviz\n",
     "\n",
     "import qrules\n",
-    "from qrules.topology import create_isobar_topologies, create_n_body_topology"
+    "from qrules.topology import (\n",
+    "    create_isobar_topologies,\n",
+    "    create_n_body_topology,\n",
+    ")"
    ]
   },
   {
@@ -259,7 +262,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dot = qrules.io.asdot(reaction.transitions[::50][:3])  # just some selection"
+    "dot = qrules.io.asdot(\n",
+    "    reaction.transitions[::50][:3]\n",
+    ")  # just some selection"
    ]
   },
   {


### PR DESCRIPTION
Input code cells that are too wide get a scroll bar. That's ok, but it looks just a bit better when you can see the entire code without scrolling.