### PR TITLE
feat: allow setting custom topologies in STM

### DIFF
--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -252,6 +252,7 @@
     "usage/particle\n",
     "usage/visualize\n",
     "usage/conservation\n",
+    "usage/custom-topology\n",
     "```"
    ]
   }

--- a/docs/usage/custom-topology.ipynb
+++ b/docs/usage/custom-topology.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true,
+    "hideOutput": true,
+    "hidePrompt": true,
+    "jupyter": {
+     "source_hidden": true
+    },
+    "slideshow": {
+     "slide_type": "skip"
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "%config Completer.use_jedi = False\n",
+    "%config InlineBackend.figure_formats = ['svg']\n",
+    "import os\n",
+    "\n",
+    "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)\n",
+    "\n",
+    "# Install on Google Colab\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "from IPython import get_ipython\n",
+    "\n",
+    "install_packages = \"google.colab\" in str(get_ipython())\n",
+    "if install_packages:\n",
+    "    for package in [\"qrules[doc]\", \"graphviz\"]:\n",
+    "        subprocess.check_call(\n",
+    "            [sys.executable, \"-m\", \"pip\", \"install\", package]\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Custom topologies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As illustrated in {doc}`/usage/reaction`, the {class}`.StateTransitionManager` offers you a bit more flexibility than the façade function {func}`.generate_transitions` used in the main {doc}`/usage` page. In this notebook, we go one step further, by specifying a custom {class}`.Topology` via {attr}`.StateTransitionManager.topologies`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import graphviz\n",
+    "\n",
+    "import qrules\n",
+    "from qrules import InteractionType, StateTransitionManager\n",
+    "from qrules.topology import Edge, Topology"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2-to-2 topology"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a simple example, we start with a 2-to-2 scattering topology. We define it as follows:\n",
+    "\n",
+    ":::{margin}\n",
+    "\n",
+    "We use the fact that {class}`.Topology` can be constructed with {class}`~typing.Iterable`s, like the ones created with {obj}`range` and {func}`enumerate`.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topology = Topology(\n",
+    "    nodes=range(2),\n",
+    "    edges=enumerate(\n",
+    "        [\n",
+    "            Edge(None, 0),\n",
+    "            Edge(None, 0),\n",
+    "            Edge(1, None),\n",
+    "            Edge(1, None),\n",
+    "            Edge(0, 1),\n",
+    "        ],\n",
+    "        -2,\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "dot = qrules.io.asdot(\n",
+    "    topology,\n",
+    "    render_resonance_id=True,\n",
+    "    render_node=True,\n",
+    "    render_initial_state_id=True,\n",
+    ")\n",
+    "graphviz.Source(dot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we construct a {class}`.StateTransitionManager` for the transition $K^-K^+ \\to \\pi^+\\pi^-$. The constructed {class}`.Topology` can then be inserted via its {attr}`~.StateTransitionManager.topologies` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stm = StateTransitionManager(\n",
+    "    initial_state=[\"K-\", \"K+\"],\n",
+    "    final_state=[\"pi-\", \"pi+\"],\n",
+    "    formalism=\"canonical\",\n",
+    ")\n",
+    "stm.set_allowed_interaction_types([InteractionType.STRONG, InteractionType.EM])\n",
+    "stm.topologies = (topology,)  # tuple is immutable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the rest, the process is just the same as in {doc}`/usage/reaction`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem_sets = stm.create_problem_sets()\n",
+    "reaction_kk = stm.find_solutions(problem_sets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "dot = qrules.io.asdot(reaction_kk, collapse_graphs=True)\n",
+    "graphviz.Source(dot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{warning}\n",
+    "\n",
+    "It is not yet possible to give the initial state a certain energy. So some collider process like $e^-e^+\\to\\pi^+\\pi$ does not result in a large number of resonances.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stm.initial_state = [\"e-\", \"e+\"]\n",
+    "problem_sets = stm.create_problem_sets()\n",
+    "reaction_ep = stm.find_solutions(problem_sets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "dot = qrules.io.asdot(reaction_ep, collapse_graphs=True)\n",
+    "graphviz.Source(dot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What can do at most, is switch off {class}`.MassConservation`, either through the constructor of the {class}`.StateTransitionManager`, or by modifying {class}`.ProblemSet`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stm = StateTransitionManager(\n",
+    "    initial_state=[\"e-\", \"e+\"],\n",
+    "    final_state=[\"pi-\", \"pi+\"],\n",
+    "    formalism=\"canonical\",\n",
+    "    mass_conservation_factor=None,\n",
+    ")\n",
+    "stm.set_allowed_interaction_types([InteractionType.STRONG, InteractionType.EM])\n",
+    "stm.topologies = [topology]\n",
+    "problem_sets = stm.create_problem_sets()\n",
+    "reaction_ep_no_mass = stm.find_solutions(problem_sets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "dot = qrules.io.asdot(reaction_ep_no_mass, collapse_graphs=True)\n",
+    "graphviz.Source(dot)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -142,6 +142,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    ":::{tip}\n",
+    "\n",
+    "{doc}`custom-topology` shows how to provide custom `.Topology` instances to the STM, so that you generate more than just isobar decays.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 2. Prepare Problem Sets"
    ]
   },

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -308,9 +308,12 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         use_nbody_topology = False
         topology_building = topology_building.lower()
         if topology_building == "isobar":
-            self.__topologies = create_isobar_topologies(len(final_state))
+            self.topologies: Tuple[Topology, ...] = create_isobar_topologies(
+                len(final_state)
+            )
+            """`.Topology` instances over which the STM propagates quantum numbers."""
         elif "n-body" in topology_building or "nbody" in topology_building:
-            self.__topologies = (
+            self.topologies = (
                 create_n_body_topology(len(initial_state), len(final_state)),
             )
             use_nbody_topology = True
@@ -400,7 +403,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
 
     def create_problem_sets(self) -> Dict[float, List[ProblemSet]]:
         problem_sets = []
-        for topology in self.__topologies:
+        for topology in self.topologies:
             for initial_facts in create_initial_facts(
                 topology=topology,
                 particle_db=self.__particles,


### PR DESCRIPTION
Closes #96 

Made the `StateTransitionManager.topologies` attribute public, so that it's easier to feed custom topologies to the `StateTransitionManager`. Note that the `topologies` attribute is immutable and can only be modified by overwriting it, so I decided to avoid cluttering the code with additional setters and getters.

An example for 2-to-2 topologies (see also #29)  is illustrated in a new notebook.