### PR TITLE
fix: remove references to the expert system

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,9 +178,8 @@ nitpick_ignore = [
 # Intersphinx settings
 intersphinx_mapping = {
     "ampform": ("https://ampform.readthedocs.io/en/stable", None),
-    "compwa-org": ("https://compwa-org.readthedocs.io/en/stable", None),
-    "expertsystem": ("https://expertsystem.readthedocs.io/en/stable", None),
     "attrs": ("https://www.attrs.org/en/stable", None),
+    "compwa-org": ("https://compwa-org.readthedocs.io/en/stable", None),
     "constraint": (
         "https://labix.org/doc/constraint/public",
         "constraint.inv",

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,11 @@
 
 :::{margin}
 
-The original project was the {doc}`PWA Expert System <expertsystem:index>`.
-QRules originates from its {mod}`~expertsystem.reaction` module.
+The original project was the
+[PWA Expert System](https://expertsystem.readthedocs.io). QRules originates
+from its
+[`reaction`](https://expertsystem.readthedocs.io/en/stable/api/expertsystem.reaction.html)
+module.
 
 :::
 

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -94,11 +94,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "````{margin}\n",
-    "```{hint}\n",
+    ":::{margin}\n",
+    "\n",
     "How does the {class}`.StateTransitionManager` know what a `\"J/psi(1S)\"` is? Upon construction, the {class}`.StateTransitionManager` loads default definitions from the [PDG](https://pdg.lbl.gov). See {doc}`/usage/particle` for how to add custom particle definitions.\n",
-    "```\n",
-    "````"
+    "\n",
+    ":::"
    ]
   },
   {

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -53,9 +53,9 @@
    "source": [
     "A {doc}`Partial Wave Analysis <pwa:index>` starts by defining an amplitude model that describes the reaction process that is to be analyzed. Such a model is generally very complex and requires a fair amount of effort by the analyst (you). This gives a lot of room for mistakes.\n",
     "\n",
-    "The [‘expert system’](https://en.wikipedia.org/wiki/Expert_system) is responsible to give you advice on the form of an amplitude model, based on the problem set you define (initial state, final state, allowed interactions, intermediate states, etc.). Internally, the system propagates the quantum numbers through the reaction graph while satisfying the specified conservation rules. How to control this procedure is explained in more detail below.\n",
+    "QRules is responsible to give you advice on the form of an amplitude model, based on the problem set you define (initial state, final state, allowed interactions, intermediate states, etc.). Internally, the system propagates the quantum numbers through the reaction graph while satisfying the specified conservation rules. How to control this procedure is explained in more detail below.\n",
     "\n",
-    "Afterwards, the amplitude model of the expert system can be exported into {doc}`TensorWaves <tensorwaves:index>`. The model can for instance be used to generate a data set (toy Monte Carlo) for this reaction and to optimize its parameters to resemble an actual data set as good as possible. For more info on that see {doc}`ampform:usage/amplitude`."
+    "Afterwards, the amplitude model produced by {doc}`AmpForm <ampform:index>` can be exported into {doc}`TensorWaves <tensorwaves:index>`. The model can for instance be used to generate a data set (toy Monte Carlo) for this reaction and to optimize its parameters to resemble an actual data set as good as possible. For more info on that see {doc}`ampform:usage/amplitude`."
    ]
   },
   {
@@ -191,7 +191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get an idea of what these {class}`.ProblemSet`s represent, you can use {func}`.asdot` and {doc}`graphviz:index` to visualize one of them (see {doc}`usage/visualize`):"
+    "To get an idea of what these {class}`.ProblemSet`s represent, you can use {func}`.asdot` and {doc}`graphviz:index` to visualize one of them (see {doc}`visualize`):"
    ]
   },
   {
@@ -321,7 +321,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now note that, since a $\\gamma$ particle appears in one of the interaction nodes, the expert system knows that this node **must involve EM interactions**! Because the node can be an effective interaction, the weak interaction cannot be excluded, as it contains only a subset of conservation laws.\n",
+    "Now note that, since a $\\gamma$ particle appears in one of the interaction nodes, {mod}`qrules` knows that this node **must involve EM interactions**! Because the node can be an effective interaction, the weak interaction cannot be excluded, as it contains only a subset of conservation laws.\n",
     "\n",
     "Since only the strong interaction was supposed to be used, this results in a warning and the STM automatically corrects the mistake.\n",
     "\n",
@@ -363,7 +363,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Unfortunately, the $\\rho^0$ mainly decays into $\\pi^0+\\pi^0$, not $\\gamma+\\pi^0$ and is therefore suppressed. This information is currently not known to the expert system, but it is possible to hand the expert system a list of allowed intermediate states."
+    "Unfortunately, the $\\rho^0$ mainly decays into $\\pi^0+\\pi^0$, not $\\gamma+\\pi^0$ and is therefore suppressed. This information is currently not known to {mod}`qrules`, but it is possible to hand {mod}`qrules` a list of allowed intermediate states."
    ]
   },
   {

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -173,7 +173,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As noted in {doc}`usage/reaction`, the {class}`.StateTransitionManager` provides more control than the façade function {func}`.generate_transitions`. One advantages, is that the {class}`.StateTransitionManager` first generates a set of {class}`.ProblemSet`s with {meth}`.create_problem_sets` that you can further configure if you wish."
+    "As noted in {doc}`reaction`, the {class}`.StateTransitionManager` provides more control than the façade function {func}`.generate_transitions`. One advantages, is that the {class}`.StateTransitionManager` first generates a set of {class}`.ProblemSet`s with {meth}`.create_problem_sets` that you can further configure if you wish."
    ]
   },
   {

--- a/src/qrules/argument_handling.py
+++ b/src/qrules/argument_handling.py
@@ -154,16 +154,14 @@ class _ValueExtractor(Generic[_ElementType]):
 class _CompositeArgumentCreator:
     def __init__(self, class_type: type) -> None:
         self.__class_type = class_type
-        self.__extractors = dict(
-            {
-                class_field.name: _ValueExtractor[EdgeQuantumNumber](
-                    class_field.type
-                )
-                if _is_edge_quantum_number(class_field.type)
-                else _ValueExtractor[NodeQuantumNumber](class_field.type)
-                for class_field in attr.fields(class_type)
-            }
-        )
+        self.__extractors = {
+            class_field.name: _ValueExtractor[EdgeQuantumNumber](
+                class_field.type
+            )
+            if _is_edge_quantum_number(class_field.type)
+            else _ValueExtractor[NodeQuantumNumber](class_field.type)
+            for class_field in attr.fields(class_type)
+        }
 
     def __call__(
         self,

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -445,15 +445,13 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                     for edge_qn, qn_value in particle_props.items():
                         intermediate_edge_domains[edge_qn].add(qn_value)
 
-                return dict(
-                    {
-                        k: list(v)
-                        for k, v in intermediate_edge_domains.items()
-                        if k is not EdgeQuantumNumbers.pid
-                        and k is not EdgeQuantumNumbers.mass
-                        and k is not EdgeQuantumNumbers.width
-                    }
-                )
+                return {
+                    k: list(v)
+                    for k, v in intermediate_edge_domains.items()
+                    if k is not EdgeQuantumNumbers.pid
+                    and k is not EdgeQuantumNumbers.mass
+                    and k is not EdgeQuantumNumbers.width
+                }
 
             return self.interaction_type_settings[InteractionType.WEAK][
                 0


### PR DESCRIPTION
Links in the documentation were sometimes still pointing to the `expertsystem` website. Best avoided by keeping `intersphinx_mapping` as small as possible.