### PR TITLE
feat: allow render_node with strip_spin

### DIFF
--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -342,6 +342,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "or, with stripped node properties:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dot = qrules.io.asdot(\n",
+    "    reaction.transitions[:3], strip_spin=True, render_node=True\n",
+    ")\n",
+    "graphviz.Source(dot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "```{note}\n",
     "By default, `.asdot` renders edge IDs, because they represent the (final) state IDs as well. In the example above, we switched this off.\n",
     "```"

--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -72,11 +72,16 @@ def graph_list_to_dot(
         graphs = _collapse_graphs(graphs)
     elif strip_spin:
         if render_node:
-            raise ValueError(
-                "Graphs without spin projections cannot be rendered with node"
-                " properties"
-            )
-        graphs = _get_particle_graphs(graphs)
+            stripped_graphs = []
+            for graph in graphs:
+                if isinstance(graph, StateTransition):
+                    graph = graph.to_graph()
+                stripped_graph = _strip_projections(graph)
+                if stripped_graph not in stripped_graphs:
+                    stripped_graphs.append(stripped_graph)
+            graphs = stripped_graphs
+        else:
+            graphs = _get_particle_graphs(graphs)
     dot = ""
     if not isinstance(graphs, abc.Sequence):
         graphs = list(graphs)


### PR DESCRIPTION
This PR makes it possible to render `StateTransition`s with their node properties (`render_node=True`) _and_ stripped spin projections. This is required for #124.