### PR TITLE
feat: make Topology ordered

### DIFF
--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -143,7 +143,7 @@ def _to_optional_int(optional_int: Optional[int]) -> Optional[int]:
     return int(optional_int)
 
 
-@attr.frozen
+@attr.frozen(order=True)
 class Edge:
     """Struct-like definition of an edge, used in `Topology`."""
 
@@ -167,7 +167,7 @@ def _to_frozenset(iterable: Iterable[int]) -> FrozenSet[int]:
 
 
 @implement_pretty_repr()
-@attr.frozen
+@attr.frozen(order=True)
 class Topology:
     """Directed Feynman-like graph without edge or node properties.
 

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -249,6 +249,22 @@ class TestTopology:
         topology = topology.swap_edges(4, 6)
         assert topology != original_topology
 
+    @pytest.mark.parametrize(
+        ("n_final_states", "expected_order"),
+        [
+            (2, [0]),
+            (3, [0]),
+            (4, [1, 0]),
+            (5, [3, 2, 4, 1, 0]),
+            (6, [13, 9, 7, 10, 6, 5, 14, 11, 8, 15, 3, 2, 12, 4, 1, 0]),
+        ],
+    )
+    def test_unique_ordering(self, n_final_states, expected_order):
+        topologies = create_isobar_topologies(n_final_states)
+        sorted_topologies = sorted(topologies)
+        order = [sorted_topologies.index(t) for t in topologies]
+        assert order == expected_order
+
 
 @pytest.mark.parametrize(
     ("n_final", "n_topologies", "exception"),


### PR DESCRIPTION
This can be used to create a unique, deterministic ordered list of `Topology` instances. See https://github.com/ComPWA/ampform/issues/6, where one needs a unique way of picking a reference topology.