### PR TITLE
feat: implement Topology.relabel_edges()

### DIFF
--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -337,6 +337,12 @@ class Topology:
             new_edges[new_edge_id] = self.edges[edge_id]
         return attr.evolve(self, edges=new_edges)
 
+    def relabel_edges(self, old_to_new_id: Mapping[int, int]) -> "Topology":
+        new_edges = {
+            old_to_new_id.get(i, i): edge for i, edge in self.edges.items()
+        }
+        return attr.evolve(self, edges=new_edges)
+
     def swap_edges(self, edge_id1: int, edge_id2: int) -> "Topology":
         new_edges = dict(self.edges.items())
         new_edges.update(

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -331,6 +331,23 @@ class Topology:
         return self.relabel_edges(old_to_new_id)
 
     def relabel_edges(self, old_to_new_id: Mapping[int, int]) -> "Topology":
+        """Create a new `Topology` with new edge IDs.
+
+        This method is particularly useful when creating permutations of a
+        `Topology`, e.g.:
+
+        >>> topologies = create_isobar_topologies(3)
+        >>> len(topologies)
+        1
+        >>> topology = topologies[0]
+        >>> final_state_ids = topologies[0].outgoing_edge_ids
+        >>> permuted_topologies = {
+        ...     topology.relabel_edges(dict(zip(final_state_ids, permutation)))
+        ...     for permutation in itertools.permutations(final_state_ids)
+        ... }
+        >>> len(permuted_topologies)
+        3
+        """
         new_edges = {
             old_to_new_id.get(i, i): edge for i, edge in self.edges.items()
         }

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -340,7 +340,7 @@ class Topology:
         >>> len(topologies)
         1
         >>> topology = topologies[0]
-        >>> final_state_ids = topologies[0].outgoing_edge_ids
+        >>> final_state_ids = topology.outgoing_edge_ids
         >>> permuted_topologies = {
         ...     topology.relabel_edges(dict(zip(final_state_ids, permutation)))
         ...     for permutation in itertools.permutations(final_state_ids)

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -240,6 +240,13 @@ class TestTopology:
         assert topology.outgoing_edge_ids == frozenset({0, 1, 2})
         assert topology.intermediate_edge_ids == frozenset({3, 4})
 
+    def test_relabel_edges(self, two_to_three_decay: Topology):
+        assert set(two_to_three_decay.edges) == {0, 1, 2, 3, 4, 5, 6}
+        relabeled_topology = two_to_three_decay.relabel_edges({0: -2, 1: -1})
+        assert set(relabeled_topology.edges) == {-2, -1, 2, 3, 4, 5, 6}
+        relabeled_topology = relabeled_topology.relabel_edges({2: 0, 3: 1})
+        assert set(relabeled_topology.edges) == {-2, -1, 0, 1, 4, 5, 6}
+
     def test_swap_edges(self, two_to_three_decay: Topology):
         original_topology = two_to_three_decay
         topology = original_topology.swap_edges(0, 1)


### PR DESCRIPTION
See how to use this method to permutate final state IDs in a `Topology` case [here](https://qrules--138.org.readthedocs.build/en/138/api/qrules.topology.html#qrules.topology.Topology.relabel_edges).