### PR TITLE
feat: implement global settings.NumberOfThreads

### DIFF
--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -349,8 +349,9 @@ def generate_transitions(  # pylint: disable=too-many-arguments
             - :code:`"nbody"`: Use one central node and connect initial and final
               states to it
 
-        number_of_threads (int): Number of cores with which to compute the
-            allowed transitions. Defaults to all cores on the system.
+        number_of_threads: Number of cores with which to compute the allowed
+            transitions. Defaults to the current value returned by
+            :meth:`.settings.NumberOfThreads.get`.
 
     An example (where, for illustrative purposes only, we specify all
     arguments) would be:

--- a/src/qrules/settings.py
+++ b/src/qrules/settings.py
@@ -7,6 +7,7 @@ It is possible to change some settings from the outside, for instance:
 >>> qrules.settings.MAX_SPIN_MAGNITUDE = 3
 """
 
+import multiprocessing
 from copy import deepcopy
 from enum import Enum, auto
 from os.path import dirname, join, realpath
@@ -283,6 +284,26 @@ def _create_domains(particle_db: ParticleCollection) -> Dict[Any, list]:
         domains[EdgeQN.isospin_magnitude]
     )
     return domains
+
+
+class NumberOfThreads:
+    __n_cores: Optional[int] = None
+
+    @classmethod
+    def get(cls) -> int:
+        if cls.__n_cores is None:
+            return multiprocessing.cpu_count()
+        return cls.__n_cores
+
+    @classmethod
+    def set(cls, n_cores: Optional[int]) -> None:  # noqa: A003
+        """Set the number of threads; use `None` for all available cores."""
+        if n_cores is not None and not isinstance(n_cores, int):
+            raise TypeError(
+                "Can only set the number of cores to an integer or to None"
+                " (meaning all available cores)"
+            )
+        cls.__n_cores = n_cores
 
 
 def __positive_halves_domain(

--- a/tests/channels/test_d0_to_ks_kp_km.py
+++ b/tests/channels/test_d0_to_ks_kp_km.py
@@ -10,7 +10,6 @@ def test_script():
             "a(2)(1320)-",
             "phi(1020)",
         ],
-        number_of_threads=1,
     )
     assert len(reaction.transition_groups) == 3
     assert len(reaction.transition_groups[0]) == 2

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -39,7 +39,6 @@ def test_number_of_solutions(
         particle_db=particle_database,
         allowed_interaction_types=["strong", "EM"],
         allowed_intermediate_particles=allowed_intermediate_particles,
-        number_of_threads=1,
         formalism="helicity",
     )
     assert len(reaction.transition_groups) == n_topologies
@@ -57,7 +56,6 @@ def test_id_to_particle_mappings(particle_database):
         particle_db=particle_database,
         allowed_interaction_types="strong",
         allowed_intermediate_particles=["f(0)(980)"],
-        number_of_threads=1,
         formalism="helicity",
     )
     assert len(reaction.transition_groups) == 1

--- a/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
+++ b/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
@@ -18,7 +18,6 @@ def test_simple(formalism, n_solutions, particle_database):
         particle_db=particle_database,
         formalism=formalism,
         allowed_interaction_types="strong",
-        number_of_threads=1,
     )
     assert len(reaction.transition_groups) == 1
     assert len(reaction.transitions) == n_solutions
@@ -39,7 +38,6 @@ def test_full(formalism, n_solutions, particle_database):
         particle_db=particle_database,
         allowed_intermediate_particles=["D*"],
         formalism=formalism,
-        number_of_threads=1,
     )
     stm.set_allowed_interaction_types([InteractionType.STRONG])
     stm.add_final_state_grouping([["D0", "pi0"], ["D~0", "pi0"]])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,11 @@ import pytest
 
 from qrules import load_default_particles
 from qrules.particle import ParticleCollection
+from qrules.settings import NumberOfThreads
+
+# Ensure consistent test coverage when running pytest multithreaded
+# https://github.com/ComPWA/qrules/issues/11
+NumberOfThreads.set(1)
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_parity_prefactor.py
+++ b/tests/unit/test_parity_prefactor.py
@@ -62,7 +62,6 @@ def test_parity_prefactor(
         test_input.initial_state,
         test_input.final_state,
         allowed_intermediate_particles=test_input.intermediate_states,
-        number_of_threads=1,
     )
     stm.add_final_state_grouping(test_input.final_state_grouping)
     stm.set_allowed_interaction_types([InteractionType.EM])

--- a/tests/unit/test_system_control.py
+++ b/tests/unit/test_system_control.py
@@ -102,7 +102,6 @@ def test_external_edge_initialization(
         final_state,
         particle_database,
         formalism="helicity",
-        number_of_threads=1,
     )
 
     stm.set_allowed_interaction_types([InteractionType.STRONG])
@@ -366,7 +365,6 @@ def test_edge_swap(particle_database, initial_state, final_state):
         final_state,
         particle_database,
         formalism="helicity",
-        number_of_threads=1,
     )
     stm.set_allowed_interaction_types([InteractionType.STRONG])
 
@@ -412,7 +410,6 @@ def test_match_external_edges(particle_database, initial_state, final_state):
         final_state,
         particle_database,
         formalism="helicity",
-        number_of_threads=1,
     )
 
     stm.set_allowed_interaction_types([InteractionType.STRONG])
@@ -494,7 +491,6 @@ def test_external_edge_identical_particle_combinatorics(
         final_state,
         particle_database,
         formalism="helicity",
-        number_of_threads=1,
     )
     stm.set_allowed_interaction_types([InteractionType.STRONG])
     for group in final_state_groupings:

--- a/tests/unit/test_transition.py
+++ b/tests/unit/test_transition.py
@@ -194,7 +194,6 @@ class TestStateTransitionManager:
         stm = StateTransitionManager(
             initial_state=[("J/psi(1S)", [-1, +1])],
             final_state=["p", "p~", "eta"],
-            number_of_threads=1,
         )
         particle_name = "N(753)"
         with pytest.raises(


### PR DESCRIPTION
Closes #10
Closes #11

Added a new class [`NumberOfThreads`](https://qrules--140.org.readthedocs.build/en/140/api/qrules.settings.html#qrules.settings.NumberOfThreads) under the [`settings`](https://qrules--140.org.readthedocs.build/en/140/api/qrules.settings.html) module that makes it possible to set the number of threads globally. This is mainly useful in the tests, where we want to run the `StateTransitionManager` single-threaded for test coverage (#11). Previously this was done by setting `number_of_threads=1` in each test.