### PR TITLE
docs: set default graphviz background to transparent

### DIFF
--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -419,7 +419,7 @@
     "    reaction.transitions[0],\n",
     "    render_node=True,\n",
     "    size=12,\n",
-    "    bgcolor=\"transparent\",\n",
+    "    bgcolor=\"white\",\n",
     "    edge_style={\n",
     "        \"color\": \"red\",\n",
     "        \"arrowhead\": \"open\",\n",

--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -50,6 +50,8 @@ def embed_dot(func: Callable) -> Callable:
 
 
 def insert_graphviz_styling(dot: str, graphviz_attrs: Dict[str, Any]) -> str:
+    if "bgcolor" not in graphviz_attrs:
+        graphviz_attrs["bgcolor"] = None
     header = __dot_kwargs_to_header(graphviz_attrs)
     return dot.replace(_DOT_HEAD, _DOT_HEAD + header)
 

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -40,6 +40,7 @@ digraph {
     rankdir=LR;
     node [shape=point, width=0];
     edge [arrowhead=none];
+    bgcolor=none;
     "edge0" [shape=none, label="0: gamma[-1]"];
     "edge1" [shape=none, label="1: pi0[0]"];
     "edge2" [shape=none, label="2: pi0[0]"];
@@ -61,6 +62,7 @@ digraph {
     rankdir=LR;
     node [shape=point, width=0];
     edge [arrowhead=none];
+    bgcolor=none;
     "edge0" [shape=none, label="0: gamma[-1]"];
     "edge1" [shape=none, label="1: pi0[0]"];
     "edge2" [shape=none, label="2: pi0[0]"];
@@ -86,6 +88,7 @@ def test_asdot_graphviz_attrs(reaction: ReactionInfo):
     assert pydot.graph_from_dot_data(dot_data) is not None
     assert '\n    bgcolor="red";\n' in dot_data
     assert "\n    size=12;\n" in dot_data
+    assert "bgcolor=none" not in dot_data
 
 
 def test_asdot_with_styled_edges_and_nodes(reaction: ReactionInfo, output_dir):


### PR DESCRIPTION
Follow-up to #139. Consequence is that exported PNG and SVG files have no background. Preview [here](https://qrules--141.org.readthedocs.build/en/141/usage/visualize.html).

Get old behaviour with `qrules.io.asdot(..., bgcolor="white")`.