### PR TITLE
fix: match final state IDs with final state order

### DIFF
--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -69,7 +69,7 @@ ValueType = TypeVar("ValueType")
 
 @total_ordering
 class FrozenDict(  # pylint: disable=too-many-ancestors
-    Generic[KeyType, ValueType], abc.Hashable, abc.Mapping
+    abc.Hashable, abc.Mapping, Generic[KeyType, ValueType]
 ):
     def __init__(self, mapping: Optional[Mapping] = None):
         self.__mapping: Dict[KeyType, ValueType] = {}

--- a/tests/unit/test_qrules.py
+++ b/tests/unit/test_qrules.py
@@ -1,0 +1,33 @@
+import pytest
+
+from qrules import generate_transitions
+
+
+@pytest.mark.parametrize(
+    "resonance_names",
+    [
+        ["Sigma(1660)~-"],
+        ["N(1650)+"],
+        ["K*(1680)~0"],
+        ["Sigma(1660)~-", "N(1650)+"],
+        ["Sigma(1660)~-", "K*(1680)~0"],
+        ["N(1650)+", "K*(1680)~0"],
+        ["Sigma(1660)~-", "N(1650)+", "K*(1680)~0"],
+    ],
+)
+def test_generate_transitions(resonance_names):
+    final_state_names = ["K0", "Sigma+", "p~"]
+    reaction = generate_transitions(
+        initial_state="J/psi(1S)",
+        final_state=final_state_names,
+        allowed_intermediate_particles=resonance_names,
+        allowed_interaction_types="strong",
+    )
+    assert len(reaction.transition_groups) == len(resonance_names)
+    final_state = dict(enumerate(final_state_names))
+    for transition in reaction.transitions:
+        this_final_state = {
+            i: state.particle.name
+            for i, state in transition.final_states.items()
+        }
+        assert final_state == this_final_state


### PR DESCRIPTION
Closes #143 

Compare [this visualization in v0.9.5](https://qrules.readthedocs.io/en/0.9.5/usage.html#investigate-intermediate-resonances) with [the one for this PR](https://qrules--145.org.readthedocs.build/en/145/usage.html#investigate-intermediate-resonances).

- 10379d2 adds a test [that fails](https://github.com/ComPWA/qrules/runs/4980455593) the check described in #143
- 2e91cb4 [fixes](https://github.com/ComPWA/qrules/runs/4980458314) that test