### PR TITLE
fix: make ReactionInfo hashable

### DIFF
--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -935,14 +935,14 @@ def _to_tuple(
     return tuple(iterable)
 
 
-@attr.frozen(eq=False)
+@attr.frozen(eq=False, hash=True)
 class ReactionInfo:
     """`StateTransitionCollection` instances, grouped by `.Topology`."""
 
     transition_groups: Tuple[StateTransitionCollection, ...] = attr.ib(
         converter=_to_tuple
     )
-    transitions: List[StateTransition] = attr.ib(
+    transitions: Tuple[StateTransition, ...] = attr.ib(
         init=False, repr=False, eq=False
     )
     initial_state: FrozenDict[int, Particle] = attr.ib(init=False, repr=False)
@@ -958,7 +958,7 @@ class ReactionInfo:
         for grouping in self.transition_groups:
             transitions.extend(sorted(grouping))
         first_grouping = self.transition_groups[0]
-        object.__setattr__(self, "transitions", transitions)
+        object.__setattr__(self, "transitions", tuple(transitions))
         object.__setattr__(self, "final_state", first_grouping.final_state)
         object.__setattr__(self, "initial_state", first_grouping.initial_state)
 

--- a/tests/unit/test_transition.py
+++ b/tests/unit/test_transition.py
@@ -56,6 +56,11 @@ class TestReactionInfo:
         from_graphs = ReactionInfo.from_graphs(graphs, reaction.formalism)
         assert from_graphs == reaction
 
+    def test_hash(self, reaction: ReactionInfo):
+        graphs = reaction.to_graphs()
+        from_graphs = ReactionInfo.from_graphs(graphs, reaction.formalism)
+        assert hash(from_graphs) == hash(reaction)
+
 
 class TestState:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Particluarly useful for [`functools.lru_cache()`](https://docs.python.org/3/library/functools.html#functools.lru_cache).