### PR TITLE
refactor!: remove StateTransitionCollection

### DIFF
--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -466,7 +466,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "io.asdict(reaction.transition_groups[0].topology)"
+    "io.asdict(reaction.transitions[0].topology)"
    ]
   },
   {

--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -366,10 +366,10 @@ def generate_transitions(  # pylint: disable=too-many-arguments
     ...     particle_db=qrules.load_pdg(),
     ...     topology_building="isobar",
     ... )
-    >>> len(reaction.transition_groups)
-    3
     >>> len(reaction.transitions)
     4
+    >>> len(reaction.group_by_topology())
+    3
     """
     if isinstance(initial_state, str) or (
         isinstance(initial_state, tuple)

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -16,13 +16,7 @@ import yaml
 
 from qrules.particle import Particle, ParticleCollection
 from qrules.topology import StateTransitionGraph, Topology
-from qrules.transition import (
-    ProblemSet,
-    ReactionInfo,
-    State,
-    StateTransition,
-    StateTransitionCollection,
-)
+from qrules.transition import ProblemSet, ReactionInfo, State, StateTransition
 
 from . import _dict, _dot
 
@@ -33,10 +27,7 @@ def asdict(instance: object) -> dict:
         return _dict.from_particle(instance)
     if isinstance(instance, ParticleCollection):
         return _dict.from_particle_collection(instance)
-    if isinstance(
-        instance,
-        (ReactionInfo, State, StateTransition, StateTransitionCollection),
-    ):
+    if isinstance(instance, (ReactionInfo, State, StateTransition)):
         return attrs.asdict(
             instance,
             recurse=True,
@@ -59,12 +50,10 @@ def fromdict(definition: dict) -> object:
         return _dict.build_particle(definition)
     if keys == {"particles"}:
         return _dict.build_particle_collection(definition)
-    if keys == {"transition_groups", "formalism"}:
+    if keys == {"transitions", "formalism"}:
         return _dict.build_reaction_info(definition)
     if keys == {"topology", "states", "interactions"}:
         return _dict.build_state_transition(definition)
-    if keys == {"transitions"}:
-        return _dict.build_stc(definition)
     if keys == {"topology", "edge_props", "node_props"}:
         return _dict.build_stg(definition)
     if keys == __REQUIRED_TOPOLOGY_FIELDS:
@@ -153,7 +142,7 @@ def asdot(
             node_style=node_style,
         )
         return _dot.insert_graphviz_styling(dot, graphviz_attrs=figure_style)
-    if isinstance(instance, (ReactionInfo, StateTransitionCollection)):
+    if isinstance(instance, ReactionInfo):
         instance = instance.to_graphs()
     if isinstance(instance, abc.Iterable):
         dot = _dot.graph_list_to_dot(

--- a/src/qrules/io/_dict.py
+++ b/src/qrules/io/_dict.py
@@ -17,12 +17,7 @@ from qrules.particle import (
 )
 from qrules.quantum_numbers import InteractionProperties
 from qrules.topology import Edge, StateTransitionGraph, Topology
-from qrules.transition import (
-    ReactionInfo,
-    State,
-    StateTransition,
-    StateTransitionCollection,
-)
+from qrules.transition import ReactionInfo, State, StateTransition
 
 
 def from_particle_collection(particles: ParticleCollection) -> dict:
@@ -79,7 +74,7 @@ def _value_serializer(  # pylint: disable=unused-argument
             return {k: v.name for k, v in value.items()}
         return dict(value)
     if not isinstance(
-        inst, (ReactionInfo, State, StateTransition, StateTransitionCollection)
+        inst, (ReactionInfo, State, StateTransition)
     ) and isinstance(value, Particle):
         return value.name
     if isinstance(value, Parity):
@@ -114,13 +109,11 @@ def build_particle(definition: dict) -> Particle:
 
 
 def build_reaction_info(definition: dict) -> ReactionInfo:
-    transition_groups = [
-        build_stc(graph_def) for graph_def in definition["transition_groups"]
+    transitions = [
+        build_state_transition(transition_def)
+        for transition_def in definition["transitions"]
     ]
-    return ReactionInfo(
-        transition_groups=transition_groups,
-        formalism=definition["formalism"],
-    )
+    return ReactionInfo(transitions, formalism=definition["formalism"])
 
 
 def build_stg(definition: dict) -> StateTransitionGraph[ParticleWithSpin]:
@@ -143,14 +136,6 @@ def build_stg(definition: dict) -> StateTransitionGraph[ParticleWithSpin]:
         edge_props=edge_props,
         node_props=node_props,
     )
-
-
-def build_stc(definition: dict) -> StateTransitionCollection:
-    transitions = [
-        build_state_transition(graph_def)
-        for graph_def in definition["transitions"]
-    ]
-    return StateTransitionCollection(transitions=transitions)
 
 
 def build_state_transition(definition: dict) -> StateTransition:

--- a/tests/channels/test_d0_to_ks_kp_km.py
+++ b/tests/channels/test_d0_to_ks_kp_km.py
@@ -11,10 +11,11 @@ def test_script():
             "phi(1020)",
         ],
     )
-    assert len(reaction.transition_groups) == 3
-    assert len(reaction.transition_groups[0]) == 2
-    assert len(reaction.transition_groups[1]) == 1
-    assert len(reaction.transition_groups[2]) == 2
+    groupings = sorted(reaction.group_by_topology().values())
+    assert len(groupings) == 3
+    assert len(groupings[0]) == 2
+    assert len(groupings[1]) == 2
+    assert len(groupings[2]) == 1
     assert reaction.get_intermediate_particles().names == [
         "a(0)(980)-",
         "a(0)(980)0",

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -41,7 +41,7 @@ def test_number_of_solutions(
         allowed_intermediate_particles=allowed_intermediate_particles,
         formalism="helicity",
     )
-    assert len(reaction.transition_groups) == n_topologies
+    assert len(reaction.group_by_topology()) == n_topologies
     assert len(reaction.transitions) == number_of_solutions
     assert (
         reaction.get_intermediate_particles().names
@@ -58,7 +58,7 @@ def test_id_to_particle_mappings(particle_database):
         allowed_intermediate_particles=["f(0)(980)"],
         formalism="helicity",
     )
-    assert len(reaction.transition_groups) == 1
+    assert len(reaction.group_by_topology()) == 1
     assert len(reaction.transitions) == 4
     iter_transitions = iter(reaction.transitions)
     first_transition = next(iter_transitions)

--- a/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
+++ b/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
@@ -19,7 +19,7 @@ def test_simple(formalism, n_solutions, particle_database):
         formalism=formalism,
         allowed_interaction_types="strong",
     )
-    assert len(reaction.transition_groups) == 1
+    assert len(reaction.group_by_topology()) == 1
     assert len(reaction.transitions) == n_solutions
 
 
@@ -43,5 +43,5 @@ def test_full(formalism, n_solutions, particle_database):
     stm.add_final_state_grouping([["D0", "pi0"], ["D~0", "pi0"]])
     problem_sets = stm.create_problem_sets()
     reaction = stm.find_solutions(problem_sets)
-    assert len(reaction.transition_groups) == 1
+    assert len(reaction.group_by_topology()) == 1
     assert len(reaction.transitions) == n_solutions

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -20,9 +20,8 @@ from qrules.transition import ReactionInfo
 
 
 def test_asdot(reaction: ReactionInfo):
-    for grouping in reaction.transition_groups:
-        for transition in grouping:
-            dot_data = io.asdot(transition)
+    for transition in reaction.transitions:
+        dot_data = io.asdot(transition)
         assert pydot.graph_from_dot_data(dot_data) is not None
     dot_data = io.asdot(reaction)
     assert pydot.graph_from_dot_data(dot_data) is not None
@@ -186,12 +185,9 @@ class TestWrite:
             assert pydot.graph_from_dot_data(dot_data) is not None
 
     def test_write_graph_list(self, output_dir: str, reaction: ReactionInfo):
-        for i, grouping in enumerate(reaction.transition_groups):
+        for i, transition in enumerate(reaction.transitions):
             output_file = output_dir + f"test_graph_list_{i}.gv"
-            io.write(
-                instance=grouping,
-                filename=output_file,
-            )
+            io.write(transition, filename=output_file)
             with open(output_file) as stream:
                 dot_data = stream.read()
             assert pydot.graph_from_dot_data(dot_data) is not None

--- a/tests/unit/test_parity_prefactor.py
+++ b/tests/unit/test_parity_prefactor.py
@@ -69,7 +69,7 @@ def test_parity_prefactor(
 
     reaction = stm.find_solutions(problem_sets)
 
-    assert len(reaction.transition_groups) == 1
+    assert len(reaction.group_by_topology()) == 1
     for transition in reaction.transitions:
         in_edges = [
             state_id

--- a/tests/unit/test_qrules.py
+++ b/tests/unit/test_qrules.py
@@ -23,7 +23,7 @@ def test_generate_transitions(resonance_names):
         allowed_intermediate_particles=resonance_names,
         allowed_interaction_types="strong",
     )
-    assert len(reaction.transition_groups) == len(resonance_names)
+    assert len(reaction.group_by_topology()) == len(resonance_names)
     final_state = dict(enumerate(final_state_names))
     for transition in reaction.transitions:
         this_final_state = {

--- a/tests/unit/test_transition.py
+++ b/tests/unit/test_transition.py
@@ -24,7 +24,6 @@ from qrules.transition import State  # noqa: F401
 from qrules.transition import (
     ReactionInfo,
     StateTransition,
-    StateTransitionCollection,
     StateTransitionManager,
 )
 
@@ -35,9 +34,7 @@ class TestReactionInfo:
         assert reaction.final_state[0].name == "gamma"
         assert reaction.final_state[1].name == "pi0"
         assert reaction.final_state[2].name == "pi0"
-        assert len(reaction.transition_groups) == 1
-        for grouping in reaction.transition_groups:
-            assert isinstance(grouping, StateTransitionCollection)
+        assert len(reaction.group_by_topology()) == 1
         if reaction.formalism.startswith("cano"):
             assert len(reaction.transitions) == 16
         else:
@@ -171,27 +168,12 @@ class TestStateTransition:
             assert from_repr == instance
 
     def test_from_to_graph(self, reaction: ReactionInfo):
-        assert len(reaction.transition_groups) == 1
+        assert len(reaction.group_by_topology()) == 1
         assert len(reaction.transitions) in {8, 16}
         for transition in reaction.transitions:
             graph = transition.to_graph()
             from_graph = StateTransition.from_graph(graph)
             assert transition == from_graph
-
-
-class TestStateTransitionCollection:
-    @pytest.mark.parametrize("repr_method", [repr, pretty])
-    def test_repr(self, reaction: ReactionInfo, repr_method):
-        for instance in reaction.transition_groups:
-            from_repr = eval(repr_method(instance))
-            assert from_repr == instance
-
-    def test_from_to_graphs(self, reaction: ReactionInfo):
-        assert len(reaction.transition_groups) == 1
-        transition_grouping = reaction.transition_groups[0]
-        graphs = transition_grouping.to_graphs()
-        from_graphs = StateTransitionCollection.from_graphs(graphs)
-        assert transition_grouping == from_graphs
 
 
 class TestStateTransitionManager:


### PR DESCRIPTION
Removed the [`ReactionInfo.transition_groups`](https://qrules.readthedocs.io/en/0.9.6/api/qrules.transition.html#qrules.transition.ReactionInfo.transition_groups) attribute and its corresponding [`StateTransitionCollection`](https://qrules.readthedocs.io/en/0.9.6/api/qrules.transition.html#qrules.transition.StateTransitionCollection). Groupings can now be obtained with [`ReactionInfo.group_by_topology()`]().

Motivation:
- Reduces the size and complexity of the [`transition`](https://qrules.readthedocs.io/en/0.9.6/api/qrules.transition.html) module.
- Makes it easier to construct new [`ReactionInfo`](https://qrules.readthedocs.io/en/0.9.6/api/qrules.transition.html#qrules.transition.ReactionInfo) object from an iterable of [`StateTransition`](https://qrules.readthedocs.io/en/0.9.6/api/qrules.transition.html#qrules.transition.StateTransition)s (no need to group them yourself first).