### PR TITLE
refactor!: generalize STG to MutableTransition

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -47,6 +47,8 @@ rst-roles =
     mod
     ref
 rst-directives =
+    autolink-preface
+    automethod
     deprecated
     envvar
     exception

--- a/.flake8
+++ b/.flake8
@@ -32,6 +32,9 @@ ignore =
     W503
 extend-select =
     TI100
+per-file-ignores =
+    # casts with generics
+    src/qrules/topology.py:E731
 rst-roles =
     attr
     cite

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -46,6 +46,7 @@ jobs:
     name: Unit tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-11

--- a/.pylintrc
+++ b/.pylintrc
@@ -16,6 +16,7 @@ ignore-patterns=
 disable=
     duplicate-code, # https://github.com/PyCQA/pylint/issues/214
     invalid-unary-operand-type, # conflicts with attrs.field
+    line-too-long,    # automatically fixed with black
     logging-fstring-interpolation,
     missing-class-docstring,    # pydocstyle
     missing-function-docstring, # pydocstyle

--- a/.pylintrc
+++ b/.pylintrc
@@ -22,6 +22,7 @@ disable=
     missing-function-docstring, # pydocstyle
     missing-module-docstring,   # pydocstyle
     no-member, # conflicts with attrs.field
+    no-name-in-module,  # already checked by mypy
     not-an-iterable, # conflicts with attrs.field
     not-callable, # conflicts with attrs.field
     redefined-builtin, # flake8-built

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,6 +1,7 @@
 *.doctree
 *.inv
 *build/
+_images/*
 api/
 
 !_static/*

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -1,0 +1,130 @@
+# flake8: noqa
+# pylint: disable=import-error,import-outside-toplevel,invalid-name,protected-access
+# pyright: reportMissingImports=false
+"""Extend docstrings of the API.
+
+This small script is used by ``conf.py`` to dynamically modify docstrings.
+"""
+
+import inspect
+import logging
+import textwrap
+from typing import Callable, Dict, Optional, Type, Union
+
+import qrules
+
+logging.getLogger().setLevel(logging.ERROR)
+
+
+def extend_docstrings() -> None:
+    script_name = __file__.rsplit("/", maxsplit=1)[-1]
+    script_name = ".".join(script_name.split(".")[:-1])
+    definitions = dict(globals())
+    for name, definition in definitions.items():
+        module = inspect.getmodule(definition)
+        if module is None:
+            continue
+        if module.__name__ not in {"__main__", script_name}:
+            continue
+        if not inspect.isfunction(definition):
+            continue
+        if not name.startswith("extend_"):
+            continue
+        if name == "extend_docstrings":
+            continue
+        function_arguments = inspect.signature(definition).parameters
+        if len(function_arguments):
+            raise ValueError(
+                f"Local function {name} should not have a signature"
+            )
+        definition()
+
+
+def extend_create_isobar_topologies() -> None:
+    from qrules.topology import create_isobar_topologies
+
+    topologies = qrules.topology.create_isobar_topologies(4)
+    dot_renderings = map(
+        lambda t: qrules.io.asdot(t, render_resonance_id=True),
+        topologies,
+    )
+    images = [_graphviz_to_image(dot, indent=6) for dot in dot_renderings]
+    _append_to_docstring(
+        create_isobar_topologies,
+        f"""
+
+    .. panels::
+      :body: text-center
+      {images[0]}
+
+      ---
+      {images[1]}
+    """,
+    )
+
+
+def extend_create_n_body_topology() -> None:
+    from qrules.topology import create_n_body_topology
+
+    topology = create_n_body_topology(
+        number_of_initial_states=2,
+        number_of_final_states=5,
+    )
+    dot = qrules.io.asdot(topology, render_initial_state_id=True)
+    _append_to_docstring(
+        create_n_body_topology,
+        _graphviz_to_image(dot, indent=4),
+    )
+
+
+def extend_Topology() -> None:
+    from qrules.topology import Topology, create_isobar_topologies
+
+    topologies = create_isobar_topologies(number_of_final_states=3)
+    dot = qrules.io.asdot(
+        topologies[0],
+        render_initial_state_id=True,
+        render_resonance_id=True,
+    )
+    _append_to_docstring(
+        Topology,
+        _graphviz_to_image(dot, indent=4),
+    )
+
+
+def _append_to_docstring(
+    class_type: Union[Callable, Type], appended_text: str
+) -> None:
+    assert class_type.__doc__ is not None
+    class_type.__doc__ += appended_text
+
+
+_GRAPHVIZ_COUNTER = 0
+_IMAGE_DIR = "_images"
+
+
+def _graphviz_to_image(  # pylint: disable=too-many-arguments
+    dot: str,
+    options: Optional[Dict[str, str]] = None,
+    format: str = "svg",
+    indent: int = 0,
+    caption: str = "",
+    label: str = "",
+) -> str:
+    import graphviz  # type: ignore[import]
+
+    if options is None:
+        options = {}
+    global _GRAPHVIZ_COUNTER  # pylint: disable=global-statement
+    output_file = f"graphviz_{_GRAPHVIZ_COUNTER}"
+    _GRAPHVIZ_COUNTER += 1
+    graphviz.Source(dot).render(f"{_IMAGE_DIR}/{output_file}", format=format)
+    restructuredtext = "\n"
+    if label:
+        restructuredtext += f".. _{label}:\n"
+    restructuredtext += f".. figure:: /{_IMAGE_DIR}/{output_file}.{format}\n"
+    for option, value in options.items():
+        restructuredtext += f"  :{option}: {value}\n"
+    if caption:
+        restructuredtext += f"\n  {caption}\n"
+    return textwrap.indent(restructuredtext, indent * " ")

--- a/docs/_relink_references.py
+++ b/docs/_relink_references.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
 
 __TARGET_SUBSTITUTIONS = {
+    "EdgeType": "qrules.topology.EdgeType",
+    "NodeType": "qrules.topology.NodeType",
     "a set-like object providing a view on D's items": "typing.ItemsView",
     "a set-like object providing a view on D's keys": "typing.KeysView",
     "an object providing a view on D's values": "typing.ValuesView",

--- a/docs/_relink_references.py
+++ b/docs/_relink_references.py
@@ -22,6 +22,7 @@ __TARGET_SUBSTITUTIONS = {
     "a set-like object providing a view on D's keys": "typing.KeysView",
     "an object providing a view on D's values": "typing.ValuesView",
     "typing_extensions.Protocol": "typing.Protocol",
+    "typing_extensions.TypeAlias": "typing.TypeAlias",
 }
 __REF_TYPE_SUBSTITUTIONS = {
     "None": "obj",
@@ -57,6 +58,7 @@ __REF_TYPE_SUBSTITUTIONS = {
     "qrules.topology.NodeType": "obj",
     "qrules.topology.ValueType": "obj",
     "qrules.transition.StateTransition": "obj",
+    "typing.TypeAlias": "obj",
 }
 
 

--- a/docs/_relink_references.py
+++ b/docs/_relink_references.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
 
 __TARGET_SUBSTITUTIONS = {
-    "EdgeType": "qrules.topology.EdgeType",
-    "NodeType": "qrules.topology.NodeType",
     "a set-like object providing a view on D's items": "typing.ItemsView",
     "a set-like object providing a view on D's keys": "typing.KeysView",
     "an object providing a view on D's values": "typing.ValuesView",
@@ -53,10 +51,6 @@ __REF_TYPE_SUBSTITUTIONS = {
     "qrules.quantum_numbers.NodeQuantumNumbers.s_projection": "obj",
     "qrules.solving.GraphElementProperties": "obj",
     "qrules.solving.GraphSettings": "obj",
-    "qrules.topology.EdgeType": "obj",
-    "qrules.topology.KeyType": "obj",
-    "qrules.topology.NodeType": "obj",
-    "qrules.topology.ValueType": "obj",
     "qrules.transition.StateTransition": "obj",
     "typing.TypeAlias": "obj",
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,9 +73,12 @@ if os.path.exists(LOGO_PATH):
 
 # -- Generate API ------------------------------------------------------------
 sys.path.insert(0, os.path.abspath("."))
+from _extend_docstrings import extend_docstrings  # noqa: E402
 from _relink_references import relink_references  # noqa: E402
 
+extend_docstrings()
 relink_references()
+
 shutil.rmtree("api", ignore_errors=True)
 subprocess.call(
     " ".join(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,10 +227,12 @@ default_role = "py:obj"
 primary_domain = "py"
 nitpicky = True  # warn if cross-references are missing
 nitpick_ignore = [
-    ("py:class", "qrules.topology.NewEdgeType"),
-    ("py:class", "qrules.topology.NewNodeType"),
+    ("py:class", "NewEdgeType"),
+    ("py:class", "NewNodeType"),
     ("py:class", "NoneType"),
     ("py:class", "json.encoder.JSONEncoder"),
+    ("py:class", "qrules.topology.NewEdgeType"),
+    ("py:class", "qrules.topology.NewNodeType"),
     ("py:class", "typing_extensions.Protocol"),
     ("py:obj", "qrules.topology._K"),
     ("py:obj", "qrules.topology._V"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,6 +175,12 @@ autodoc_default_options = {
     ),
 }
 autodoc_member_order = "bysource"
+autodoc_type_aliases = {
+    "GraphElementProperties": "qrules.solving.GraphElementProperties",
+    "GraphSettings": "qrules.solving.GraphSettings",
+    "InitialFacts": "qrules.combinatorics.InitialFacts",
+    "StateTransition": "qrules.transition.StateTransition",
+}
 autodoc_typehints_format = "short"
 codeautolink_concat_default = True
 AUTODOC_INSERT_SIGNATURE_LINEBREAKS = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -221,10 +221,9 @@ default_role = "py:obj"
 primary_domain = "py"
 nitpicky = True  # warn if cross-references are missing
 nitpick_ignore = [
-    ("py:class", "EdgeType"),
+    ("py:class", "qrules.topology.NewEdgeType"),
+    ("py:class", "qrules.topology.NewNodeType"),
     ("py:class", "NoneType"),
-    ("py:class", "MutableTransition"),
-    ("py:class", "ValueType"),
     ("py:class", "json.encoder.JSONEncoder"),
     ("py:class", "typing_extensions.Protocol"),
     ("py:obj", "qrules.topology._K"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,16 +226,14 @@ viewcode_follow_imported_members = True
 default_role = "py:obj"
 primary_domain = "py"
 nitpicky = True  # warn if cross-references are missing
-nitpick_ignore = [
-    ("py:class", "NewEdgeType"),
-    ("py:class", "NewNodeType"),
-    ("py:class", "NoneType"),
-    ("py:class", "json.encoder.JSONEncoder"),
-    ("py:class", "qrules.topology.NewEdgeType"),
-    ("py:class", "qrules.topology.NewNodeType"),
-    ("py:class", "typing_extensions.Protocol"),
-    ("py:obj", "qrules.topology._K"),
-    ("py:obj", "qrules.topology._V"),
+nitpick_ignore_regex = [
+    (r"py:(class|obj)", "json.encoder.JSONEncoder"),
+    (r"py:(class|obj)", r"(qrules\.topology\.)?EdgeType"),
+    (r"py:(class|obj)", r"(qrules\.topology\.)?KT"),
+    (r"py:(class|obj)", r"(qrules\.topology\.)?NewEdgeType"),
+    (r"py:(class|obj)", r"(qrules\.topology\.)?NewNodeType"),
+    (r"py:(class|obj)", r"(qrules\.topology\.)?NodeType"),
+    (r"py:(class|obj)", r"(qrules\.topology\.)?VT"),
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,13 +164,19 @@ exclude_patterns = [
 # General sphinx settings
 add_module_names = False
 autodoc_default_options = {
+    "exclude-members": ", ".join(
+        [
+            "items",
+            "keys",
+            "values",
+        ]
+    ),
     "members": True,
     "undoc-members": True,
     "show-inheritance": True,
     "special-members": ", ".join(
         [
             "__call__",
-            "__getitem__",
         ]
     ),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,7 +223,7 @@ nitpicky = True  # warn if cross-references are missing
 nitpick_ignore = [
     ("py:class", "EdgeType"),
     ("py:class", "NoneType"),
-    ("py:class", "StateTransitionGraph"),
+    ("py:class", "MutableTransition"),
     ("py:class", "ValueType"),
     ("py:class", "json.encoder.JSONEncoder"),
     ("py:class", "typing_extensions.Protocol"),

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ QRules consists of three major components:
 
 1. **State transition graphs**
 
-   A {class}`.StateTransitionGraph` is a
+   A {class}`.MutableTransition` is a
    [directed graph](https://en.wikipedia.org/wiki/Directed_graph) that consists
    of **nodes** and **edges**. In a directed graph, each edge must be connected
    to at least one node (in correspondence to
@@ -93,7 +93,7 @@ The main solver used by {mod}`qrules` is the
 1. **Preparation**
 
    1.1. Build all possible topologies. A **topology** is represented by a
-   {class}`.StateTransitionGraph`, in which the edges and nodes are empty (no
+   {class}`.MutableTransition`, in which the edges and nodes are empty (no
    particle information).
 
    1.2. Fill the topology graphs with the user provided information. Typically

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -215,14 +215,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example with a {class}`.StateTransition`"
+    "## Example with a {obj}`.StateTransition`"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, generate some {class}`.StateTransition`s with {func}`.generate_transitions`, then select one of them:"
+    "First, generate some {obj}`.StateTransition`s with {func}`.generate_transitions`, then select one of them:"
    ]
   },
   {
@@ -361,14 +361,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Modifying {class}`.StateTransition`s"
+    "### Modifying {obj}`.StateTransition`s"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When checking conservation rules, you may want to modify the properties on the {class}`.StateTransition`s. However, a {class}`.StateTransition` is frozen, so it is not possible to modify its {attr}`~.StateTransition.interactions` and {attr}`~.StateTransition.states`. The only way around this is to create a new instance with {func}`attrs.evolve`.\n",
+    "When checking conservation rules, you may want to modify the properties on the {obj}`.StateTransition`s. However, a {obj}`.StateTransition` is a {class}`.FrozenTransition`, so it is not possible to modify its {attr}`~.FrozenTransition.interactions` and {attr}`~.FrozenTransition.states`. The only way around this is to create a new instance with {func}`attrs.evolve`.\n",
     "\n",
     "First, we get the instance (in this case one of the {class}`.InteractionProperties`) and substitute its {attr}`.InteractionProperties.l_magnitude`:"
    ]
@@ -387,7 +387,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We then again use {func}`attrs.evolve` to substitute the {attr}`.StateTransition.interactions` of the original {class}`.StateTransition`:"
+    "We then again use {func}`attrs.evolve` to substitute the {attr}`.Transition.interactions` of the original {obj}`.StateTransition`:"
    ]
   },
   {

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -97,7 +97,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "QRules generates {class}`.StateTransitionGraph`s, populates them with quantum numbers (edge properties representing states and nodes properties representing interactions), then checks whether the generated {class}`.StateTransitionGraph`s comply with the rules formulated in the {mod}`.conservation_rules` module.\n",
+    "QRules generates {class}`.MutableTransition`s, populates them with quantum numbers (edge properties representing states and nodes properties representing interactions), then checks whether the generated {class}`.MutableTransition`s comply with the rules formulated in the {mod}`.conservation_rules` module.\n",
     "\n",
     "The {mod}`.conservation_rules` module can also be used separately. In this notebook, we will illustrate this by checking spin and parity conservation."
    ]

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -179,7 +179,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create all {class}`.ProblemSet`'s using the boundary conditions of the {class}`.StateTransitionManager` instance. By default it uses the **isobar model** (tree of two-body decays) to build {class}`.Topology`'s. Various {class}`.InitialFacts` are created for each topology based on the initial and final state. Lastly some reasonable default settings for the solving process are chosen. Remember that each interaction node defines its own set of conservation laws."
+    "Create all {class}`.ProblemSet`'s using the boundary conditions of the {class}`.StateTransitionManager` instance. By default it uses the **isobar model** (tree of two-body decays) to build {class}`.Topology`'s. Various {obj}`.InitialFacts` are created for each topology based on the initial and final state. Lastly some reasonable default settings for the solving process are chosen. Remember that each interaction node defines its own set of conservation laws."
    ]
   },
   {
@@ -247,10 +247,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each {class}`.ProblemSet` provides a mapping of {attr}`~.ProblemSet.initial_facts` that represent the initial and final states with spin projections. The nodes and edges in between these {attr}`~.ProblemSet.initial_facts` are still to be generated. This will be done from the provided {attr}`~.ProblemSet.solving_settings` ({class}`~.GraphSettings`). There are two mechanisms there:\n",
+    "Each {class}`.ProblemSet` provides a mapping of {attr}`~.ProblemSet.initial_facts` that represent the initial and final states with spin projections. The nodes and edges in between these {attr}`~.ProblemSet.initial_facts` are still to be generated. This will be done from the provided {attr}`~.ProblemSet.solving_settings`. There are two mechanisms there:\n",
     "\n",
-    "1. One the one hand, the {attr}`.EdgeSettings.qn_domains` and {attr}`.NodeSettings.qn_domains` contained in the {class}`~.GraphSettings` define the **domain** over which quantum number sets can be generated.\n",
-    "2. On the other, the {attr}`.EdgeSettings.rule_priorities` and {attr}`.NodeSettings.rule_priorities` in {class}`~.GraphSettings` define which **{mod}`.conservation_rules`** are used to determine which of the sets of generated quantum numbers are valid.\n",
+    "1. One the one hand, the {attr}`.EdgeSettings.qn_domains` and {attr}`.NodeSettings.qn_domains` contained in the {attr}`~.ProblemSet.solving_settings` define the **domain** over which quantum number sets can be generated.\n",
+    "2. On the other, the {attr}`.EdgeSettings.rule_priorities` and {attr}`.NodeSettings.rule_priorities` in {attr}`~.ProblemSet.solving_settings` define which **{mod}`.conservation_rules`** are used to determine which of the sets of generated quantum numbers are valid.\n",
     "\n",
     "Together, these two constraints allow the {class}`.StateTransitionManager` to generate a number of {class}`.MutableTransition`s that comply with the selected {mod}`.conservation_rules`."
    ]

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -252,7 +252,7 @@
     "1. One the one hand, the {attr}`.EdgeSettings.qn_domains` and {attr}`.NodeSettings.qn_domains` contained in the {class}`~.GraphSettings` define the **domain** over which quantum number sets can be generated.\n",
     "2. On the other, the {attr}`.EdgeSettings.rule_priorities` and {attr}`.NodeSettings.rule_priorities` in {class}`~.GraphSettings` define which **{mod}`.conservation_rules`** are used to determine which of the sets of generated quantum numbers are valid.\n",
     "\n",
-    "Together, these two constraints allow the {class}`.StateTransitionManager` to generate a number of {class}`.StateTransitionGraph`s that comply with the selected {mod}`.conservation_rules`."
+    "Together, these two constraints allow the {class}`.StateTransitionManager` to generate a number of {class}`.MutableTransition`s that comply with the selected {mod}`.conservation_rules`."
    ]
   },
   {
@@ -313,7 +313,7 @@
     "class: dropdown\n",
     "----\n",
     "\n",
-    "The \"number of {attr}`~.ReactionInfo.transitions`\" is the total number of allowed {obj}`.StateTransitionGraph` instances that the {class}`.StateTransitionManager` has found. This also includes all allowed **spin projection combinations**. In this channel, we for example consider a $J/\\psi$ with spin projection $\\pm1$ that decays into a $\\gamma$ with spin projection $\\pm1$, which already gives us four possibilities.\n",
+    "The \"number of {attr}`~.ReactionInfo.transitions`\" is the total number of allowed {obj}`.MutableTransition` instances that the {class}`.StateTransitionManager` has found. This also includes all allowed **spin projection combinations**. In this channel, we for example consider a $J/\\psi$ with spin projection $\\pm1$ that decays into a $\\gamma$ with spin projection $\\pm1$, which already gives us four possibilities.\n",
     "\n",
     "On the other hand, the intermediate state names that was extracted with {meth}`.ReactionInfo.get_intermediate_particles`, is just a {obj}`set` of the state names on the intermediate edges of the list of {attr}`~.ReactionInfo.transitions`, regardless of spin projection.\n",
     "````"
@@ -457,7 +457,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The {class}`.ReactionInfo`, {class}`.StateTransitionGraph`, and {class}`.Topology` can be serialized to and from a {obj}`dict` with {func}`.io.asdict` and {func}`.io.fromdict`:"
+    "The {class}`.ReactionInfo`, {class}`.MutableTransition`, and {class}`.Topology` can be serialized to and from a {obj}`dict` with {func}`.io.asdict` and {func}`.io.fromdict`:"
    ]
   },
   {

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -255,7 +255,7 @@
     "tags": []
    },
    "source": [
-    "## {class}`.StateTransition`s"
+    "## {obj}`.StateTransition`s"
    ]
   },
   {

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -81,7 +81,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The {mod}`~qrules.io` module allows you to convert {class}`.StateTransitionGraph`, {class}`.Topology` instances, and {class}`.ProblemSet`s to [DOT language](https://graphviz.org/doc/info/lang.html) with {func}`.asdot`. You can visualize its output with third-party libraries, such as [Graphviz](https://graphviz.org). This is particularly useful after running {meth}`~.StateTransitionManager.find_solutions`, which produces a {class}`.ReactionInfo` object with a {class}`.list` of {class}`.StateTransitionGraph` instances (see {doc}`/usage/reaction`)."
+    "The {mod}`~qrules.io` module allows you to convert {class}`.MutableTransition`, {class}`.Topology` instances, and {class}`.ProblemSet`s to [DOT language](https://graphviz.org/doc/info/lang.html) with {func}`.asdot`. You can visualize its output with third-party libraries, such as [Graphviz](https://graphviz.org). This is particularly useful after running {meth}`~.StateTransitionManager.find_solutions`, which produces a {class}`.ReactionInfo` object with a {class}`.list` of {class}`.MutableTransition` instances (see {doc}`/usage/reaction`)."
    ]
   },
   {
@@ -300,7 +300,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This {class}`str` of [DOT language](https://graphviz.org/doc/info/lang.html) for the list of {class}`.StateTransitionGraph` instances can then be visualized with a third-party library, for instance, with {class}`graphviz.Source`:"
+    "This {class}`str` of [DOT language](https://graphviz.org/doc/info/lang.html) for the list of {class}`.MutableTransition` instances can then be visualized with a third-party library, for instance, with {class}`graphviz.Source`:"
    ]
   },
   {

--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -140,6 +140,7 @@ def check_reaction_violations(  # pylint: disable=too-many-arguments
             topology=topology,
             initial_facts=facts,
             solving_settings=GraphSettings(
+                facts.topology,
                 interactions={
                     i: NodeSettings(conservation_rules=rules)
                     for i, rules in node_rules.items()

--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -140,11 +140,11 @@ def check_reaction_violations(  # pylint: disable=too-many-arguments
             topology=topology,
             initial_facts=facts,
             solving_settings=GraphSettings(
-                node_settings={
+                interactions={
                     i: NodeSettings(conservation_rules=rules)
                     for i, rules in node_rules.items()
                 },
-                edge_settings={
+                states={
                     i: EdgeSettings(conservation_rules=rules)
                     for i, rules in edge_rules.items()
                 },

--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -7,9 +7,9 @@ for a particle reaction problem are for example the initial state, final state,
 and allowed interactions.
 
 The core of `qrules` computes which transitions (represented by a
-`.StateTransitionGraph`) are allowed between a certain initial and final state.
+`.MutableTransition`) are allowed between a certain initial and final state.
 Internally, the system propagates the quantum numbers defined by the
-`particle` module through the `.StateTransitionGraph`, while
+`particle` module through the `.MutableTransition`, while
 satisfying the rules define by the :mod:`.conservation_rules` module. See
 :doc:`/usage/reaction` and :doc:`/usage/particle`.
 

--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -239,7 +239,7 @@ def check_reaction_violations(  # pylint: disable=too-many-arguments
         for facts_combination in initial_facts:
             new_facts = attrs.evolve(
                 facts_combination,
-                node_props={node_id: ls_combi},
+                interactions={node_id: ls_combi},
             )
             initial_facts_list.append(new_facts)
 

--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -62,14 +62,8 @@ from .settings import (
     _halves_domain,
     _int_domain,
 )
-from .solving import (
-    GraphSettings,
-    NodeSettings,
-    QNResult,
-    Rule,
-    validate_full_solution,
-)
-from .topology import create_n_body_topology
+from .solving import NodeSettings, QNResult, Rule, validate_full_solution
+from .topology import MutableTransition, create_n_body_topology
 from .transition import (
     EdgeSettings,
     ProblemSet,
@@ -139,7 +133,7 @@ def check_reaction_violations(  # pylint: disable=too-many-arguments
         problem_set = ProblemSet(
             topology=topology,
             initial_facts=facts,
-            solving_settings=GraphSettings(
+            solving_settings=MutableTransition(
                 facts.topology,
                 interactions={
                     i: NodeSettings(conservation_rules=rules)

--- a/src/qrules/__init__.py
+++ b/src/qrules/__init__.py
@@ -132,7 +132,7 @@ def check_reaction_violations(  # pylint: disable=too-many-arguments
         particle_db = load_pdg()
 
     def _check_violations(
-        facts: InitialFacts,
+        facts: "InitialFacts",
         node_rules: Dict[int, Set[Rule]],
         edge_rules: Dict[int, Set[GraphElementRule]],
     ) -> QNResult:

--- a/src/qrules/_system_control.py
+++ b/src/qrules/_system_control.py
@@ -59,7 +59,7 @@ def create_edge_properties(
 
 
 def create_node_properties(
-    node_props: InteractionProperties,
+    interactions: InteractionProperties,
 ) -> GraphNodePropertyMap:
     node_qn_mapping: Dict[str, Type[NodeQuantumNumber]] = {
         qn_name: qn_type
@@ -67,7 +67,7 @@ def create_node_properties(
         if not qn_name.startswith("__")
     }  # Note using attrs.fields does not work here because init=False
     property_map: GraphNodePropertyMap = {}
-    for qn_name, value in attrs.asdict(node_props).items():
+    for qn_name, value in attrs.asdict(interactions).items():
         if value is None:
             continue
         if qn_name in node_qn_mapping:
@@ -82,7 +82,7 @@ def create_node_properties(
 
 
 def create_particle(
-    edge_props: GraphEdgePropertyMap, particle_db: ParticleCollection
+    states: GraphEdgePropertyMap, particle_db: ParticleCollection
 ) -> ParticleWithSpin:
     """Create a Particle with spin projection from a qn dictionary.
 
@@ -90,7 +90,7 @@ def create_particle(
     particle inside the `.ParticleCollection`.
 
     Args:
-        edge_props: The quantum number dictionary.
+        states: The quantum number dictionary.
         particle_db: A `.ParticleCollection` which is used to retrieve a
           reference `.particle` to lower the memory footprint.
 
@@ -100,13 +100,13 @@ def create_particle(
 
         ValueError: If the edge properties do not contain spin projection info.
     """
-    particle = particle_db.find(int(edge_props[EdgeQuantumNumbers.pid]))
-    if EdgeQuantumNumbers.spin_projection not in edge_props:
+    particle = particle_db.find(int(states[EdgeQuantumNumbers.pid]))
+    if EdgeQuantumNumbers.spin_projection not in states:
         raise ValueError(
             f"{GraphEdgePropertyMap.__name__} does not contain a spin"
             " projection"
         )
-    spin_projection = edge_props[EdgeQuantumNumbers.spin_projection]
+    spin_projection = states[EdgeQuantumNumbers.spin_projection]
 
     return (particle, spin_projection)
 
@@ -150,9 +150,9 @@ class InteractionDeterminator(ABC):
     @abstractmethod
     def check(
         self,
-        in_edge_props: List[ParticleWithSpin],
-        out_edge_props: List[ParticleWithSpin],
-        node_props: InteractionProperties,
+        in_states: List[ParticleWithSpin],
+        out_states: List[ParticleWithSpin],
+        interactions: InteractionProperties,
     ) -> List[InteractionType]:
         pass
 
@@ -162,12 +162,12 @@ class GammaCheck(InteractionDeterminator):
 
     def check(
         self,
-        in_edge_props: List[ParticleWithSpin],
-        out_edge_props: List[ParticleWithSpin],
-        node_props: InteractionProperties,
+        in_states: List[ParticleWithSpin],
+        out_states: List[ParticleWithSpin],
+        interactions: InteractionProperties,
     ) -> List[InteractionType]:
         int_types = list(InteractionType)
-        for particle, _ in in_edge_props + out_edge_props:
+        for particle, _ in in_states + out_states:
             if "gamma" in particle.name:
                 int_types = [InteractionType.EM]
                 break
@@ -179,12 +179,12 @@ class LeptonCheck(InteractionDeterminator):
 
     def check(
         self,
-        in_edge_props: List[ParticleWithSpin],
-        out_edge_props: List[ParticleWithSpin],
-        node_props: InteractionProperties,
+        in_states: List[ParticleWithSpin],
+        out_states: List[ParticleWithSpin],
+        interactions: InteractionProperties,
     ) -> List[InteractionType]:
         node_interaction_types = list(InteractionType)
-        for particle, _ in in_edge_props + out_edge_props:
+        for particle, _ in in_states + out_states:
             if particle.is_lepton():
                 if particle.name.startswith("nu("):
                     node_interaction_types = [InteractionType.WEAK]
@@ -235,14 +235,14 @@ def _remove_qns_from_graph(  # pylint: disable=too-many-branches
     graph: MutableTransition[ParticleWithSpin, InteractionProperties],
     qn_list: Set[Type[NodeQuantumNumber]],
 ) -> MutableTransition[ParticleWithSpin, InteractionProperties]:
-    new_node_props = {}
+    new_interactions = {}
     for node_id in graph.topology.nodes:
-        node_props = graph.node_props[node_id]
-        new_node_props[node_id] = attrs.evolve(
-            node_props, **{x.__name__: None for x in qn_list}
+        interactions = graph.interactions[node_id]
+        new_interactions[node_id] = attrs.evolve(
+            interactions, **{x.__name__: None for x in qn_list}
         )
 
-    return attrs.evolve(graph, node_props=new_node_props)
+    return attrs.evolve(graph, interactions=new_interactions)
 
 
 def _check_equal_ignoring_qns(
@@ -254,13 +254,13 @@ def _check_equal_ignoring_qns(
     if not isinstance(ref_graph, MutableTransition):
         raise TypeError("Reference graph has to be of type MutableTransition")
     found_graph = None
-    node_comparator = NodePropertyComparator(ignored_qn_list)
+    interaction_comparator = NodePropertyComparator(ignored_qn_list)
     for graph in solutions:
         if isinstance(graph, MutableTransition):
             if graph.compare(
                 ref_graph,
-                edge_comparator=lambda e1, e2: e1 == e2,
-                node_comparator=node_comparator,
+                state_comparator=lambda e1, e2: e1 == e2,
+                interaction_comparator=interaction_comparator,
             ):
                 found_graph = graph
                 break
@@ -278,14 +278,14 @@ class NodePropertyComparator:
 
     def __call__(
         self,
-        node_props1: InteractionProperties,
-        node_props2: InteractionProperties,
+        interactions1: InteractionProperties,
+        interactions2: InteractionProperties,
     ) -> bool:
         return attrs.evolve(
-            node_props1,
+            interactions1,
             **{x.__name__: None for x in self.__ignored_qn_list},
         ) == attrs.evolve(
-            node_props2,
+            interactions2,
             **{x.__name__: None for x in self.__ignored_qn_list},
         )
 
@@ -365,7 +365,7 @@ def require_interaction_property(
             return False
         for i in node_ids:
             if (
-                getattr(graph.node_props[i], interaction_qn.__name__)
+                getattr(graph.interactions[i], interaction_qn.__name__)
                 not in allowed_values
             ):
                 return False
@@ -382,8 +382,8 @@ def _find_node_ids_with_ingoing_particle_name(
     found_node_ids = []
     for node_id in topology.nodes:
         for edge_id in topology.get_edge_ids_ingoing_to_node(node_id):
-            edge_props = graph.edge_props[edge_id]
-            edge_particle_name = edge_props[0].name
+            states = graph.states[edge_id]
+            edge_particle_name = states[0].name
             if str(ingoing_particle_name) in str(edge_particle_name):
                 found_node_ids.append(node_id)
                 break

--- a/src/qrules/_system_control.py
+++ b/src/qrules/_system_control.py
@@ -198,11 +198,11 @@ class LeptonCheck(InteractionDeterminator):
 
 def remove_duplicate_solutions(
     solutions: List[
-        MutableTransition[ParticleWithSpin, InteractionProperties]
+        "MutableTransition[ParticleWithSpin, InteractionProperties]"
     ],
     remove_qns_list: Optional[Set[Type[NodeQuantumNumber]]] = None,
     ignore_qns_list: Optional[Set[Type[NodeQuantumNumber]]] = None,
-) -> List[MutableTransition[ParticleWithSpin, InteractionProperties]]:
+) -> "List[MutableTransition[ParticleWithSpin, InteractionProperties]]":
     if remove_qns_list is None:
         remove_qns_list = set()
     if ignore_qns_list is None:
@@ -232,9 +232,9 @@ def remove_duplicate_solutions(
 
 
 def _remove_qns_from_graph(  # pylint: disable=too-many-branches
-    graph: MutableTransition[ParticleWithSpin, InteractionProperties],
+    graph: "MutableTransition[ParticleWithSpin, InteractionProperties]",
     qn_list: Set[Type[NodeQuantumNumber]],
-) -> MutableTransition[ParticleWithSpin, InteractionProperties]:
+) -> "MutableTransition[ParticleWithSpin, InteractionProperties]":
     new_interactions = {}
     for node_id in graph.topology.nodes:
         interactions = graph.interactions[node_id]
@@ -328,9 +328,7 @@ def require_interaction_property(
     ingoing_particle_name: str,
     interaction_qn: Type[NodeQuantumNumber],
     allowed_values: List,
-) -> Callable[
-    [MutableTransition[ParticleWithSpin, InteractionProperties]], bool
-]:
+) -> "Callable[[MutableTransition[ParticleWithSpin, InteractionProperties]], bool]":
     """Filter function.
 
     Closure, which can be used as a filter function in :func:`.filter_graphs`.
@@ -356,7 +354,7 @@ def require_interaction_property(
     """
 
     def check(
-        graph: MutableTransition[ParticleWithSpin, InteractionProperties]
+        graph: "MutableTransition[ParticleWithSpin, InteractionProperties]",
     ) -> bool:
         node_ids = _find_node_ids_with_ingoing_particle_name(
             graph, ingoing_particle_name
@@ -375,7 +373,7 @@ def require_interaction_property(
 
 
 def _find_node_ids_with_ingoing_particle_name(
-    graph: MutableTransition[ParticleWithSpin, InteractionProperties],
+    graph: "MutableTransition[ParticleWithSpin, InteractionProperties]",
     ingoing_particle_name: str,
 ) -> List[int]:
     topology = graph.topology

--- a/src/qrules/_system_control.py
+++ b/src/qrules/_system_control.py
@@ -233,7 +233,7 @@ def _remove_qns_from_graph(  # pylint: disable=too-many-branches
 ) -> StateTransitionGraph[ParticleWithSpin]:
     new_node_props = {}
     for node_id in graph.topology.nodes:
-        node_props = graph.get_node_props(node_id)
+        node_props = graph.node_props[node_id]
         new_node_props[node_id] = attrs.evolve(
             node_props, **{x.__name__: None for x in qn_list}
         )
@@ -359,7 +359,7 @@ def require_interaction_property(
             return False
         for i in node_ids:
             if (
-                getattr(graph.get_node_props(i), interaction_qn.__name__)
+                getattr(graph.node_props[i], interaction_qn.__name__)
                 not in allowed_values
             ):
                 return False
@@ -375,7 +375,7 @@ def _find_node_ids_with_ingoing_particle_name(
     found_node_ids = []
     for node_id in topology.nodes:
         for edge_id in topology.get_edge_ids_ingoing_to_node(node_id):
-            edge_props = graph.get_edge_props(edge_id)
+            edge_props = graph.edge_props[edge_id]
             edge_particle_name = edge_props[0].name
             if str(ingoing_particle_name) in str(edge_particle_name):
                 found_node_ids.append(node_id)

--- a/src/qrules/_system_control.py
+++ b/src/qrules/_system_control.py
@@ -238,7 +238,7 @@ def _remove_qns_from_graph(  # pylint: disable=too-many-branches
             node_props, **{x.__name__: None for x in qn_list}
         )
 
-    return graph.evolve(node_props=new_node_props)
+    return attrs.evolve(graph, node_props=new_node_props)
 
 
 def _check_equal_ignoring_qns(

--- a/src/qrules/_system_control.py
+++ b/src/qrules/_system_control.py
@@ -197,10 +197,12 @@ class LeptonCheck(InteractionDeterminator):
 
 
 def remove_duplicate_solutions(
-    solutions: List[StateTransitionGraph[ParticleWithSpin]],
+    solutions: List[
+        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ],
     remove_qns_list: Optional[Set[Type[NodeQuantumNumber]]] = None,
     ignore_qns_list: Optional[Set[Type[NodeQuantumNumber]]] = None,
-) -> List[StateTransitionGraph[ParticleWithSpin]]:
+) -> List[StateTransitionGraph[ParticleWithSpin, InteractionProperties]]:
     if remove_qns_list is None:
         remove_qns_list = set()
     if ignore_qns_list is None:
@@ -209,7 +211,9 @@ def remove_duplicate_solutions(
     logging.info(f"removing these qns from graphs: {remove_qns_list}")
     logging.info(f"ignoring qns in graph comparison: {ignore_qns_list}")
 
-    filtered_solutions: List[StateTransitionGraph[ParticleWithSpin]] = []
+    filtered_solutions: List[
+        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ] = []
     remove_counter = 0
     for sol_graph in solutions:
         sol_graph = _remove_qns_from_graph(sol_graph, remove_qns_list)
@@ -228,9 +232,9 @@ def remove_duplicate_solutions(
 
 
 def _remove_qns_from_graph(  # pylint: disable=too-many-branches
-    graph: StateTransitionGraph[ParticleWithSpin],
+    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
     qn_list: Set[Type[NodeQuantumNumber]],
-) -> StateTransitionGraph[ParticleWithSpin]:
+) -> StateTransitionGraph[ParticleWithSpin, InteractionProperties]:
     new_node_props = {}
     for node_id in graph.topology.nodes:
         node_props = graph.node_props[node_id]
@@ -326,7 +330,9 @@ def require_interaction_property(
     ingoing_particle_name: str,
     interaction_qn: Type[NodeQuantumNumber],
     allowed_values: List,
-) -> Callable[[StateTransitionGraph[ParticleWithSpin]], bool]:
+) -> Callable[
+    [StateTransitionGraph[ParticleWithSpin, InteractionProperties]], bool
+]:
     """Filter function.
 
     Closure, which can be used as a filter function in :func:`.filter_graphs`.
@@ -351,7 +357,9 @@ def require_interaction_property(
             - *False* otherwise
     """
 
-    def check(graph: StateTransitionGraph[ParticleWithSpin]) -> bool:
+    def check(
+        graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ) -> bool:
         node_ids = _find_node_ids_with_ingoing_particle_name(
             graph, ingoing_particle_name
         )
@@ -369,7 +377,8 @@ def require_interaction_property(
 
 
 def _find_node_ids_with_ingoing_particle_name(
-    graph: StateTransitionGraph[ParticleWithSpin], ingoing_particle_name: str
+    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
+    ingoing_particle_name: str,
 ) -> List[int]:
     topology = graph.topology
     found_node_ids = []

--- a/src/qrules/argument_handling.py
+++ b/src/qrules/argument_handling.py
@@ -93,11 +93,11 @@ def _direct_qn_check(
 
 
 def _sequence_input_check(func: Callable) -> Callable[[Sequence], bool]:
-    def wrapper(edge_props_list: Sequence[Any]) -> bool:
-        if not isinstance(edge_props_list, (list, tuple)):
+    def wrapper(states_list: Sequence[Any]) -> bool:
+        if not isinstance(states_list, (list, tuple)):
             raise TypeError("Rule evaluated with invalid argument type...")
 
-        return all(func(x) for x in edge_props_list)
+        return all(func(x) for x in states_list)
 
     return wrapper
 
@@ -170,11 +170,11 @@ class _CompositeArgumentCreator:
 
 
 def _sequence_arg_builder(func: Callable) -> Callable[[Sequence], List[Any]]:
-    def wrapper(edge_props_list: Sequence[Any]) -> List[Any]:
-        if not isinstance(edge_props_list, (list, tuple)):
+    def wrapper(states_list: Sequence[Any]) -> List[Any]:
+        if not isinstance(states_list, (list, tuple)):
             raise TypeError("Rule evaluated with invalid argument type...")
 
-        return [func(x) for x in edge_props_list if x]
+        return [func(x) for x in states_list if x]
 
     return wrapper
 

--- a/src/qrules/combinatorics.py
+++ b/src/qrules/combinatorics.py
@@ -40,8 +40,8 @@ StateDefinition = Union[str, StateWithSpins]
 @implement_pretty_repr
 @frozen
 class InitialFacts:
-    edge_props: Dict[int, ParticleWithSpin] = field(factory=dict)
-    node_props: Dict[int, InteractionProperties] = field(factory=dict)
+    states: Dict[int, ParticleWithSpin] = field(factory=dict)
+    interactions: Dict[int, InteractionProperties] = field(factory=dict)
 
 
 class _KinematicRepresentation:
@@ -268,7 +268,7 @@ def create_initial_facts(  # pylint: disable=too-many-locals
             kinematic_permutation, particle_db
         )
         edge_initial_facts.extend(
-            [InitialFacts(edge_props=x) for x in spin_permutations]
+            [InitialFacts(states=x) for x in spin_permutations]
         )
     return edge_initial_facts
 
@@ -560,4 +560,4 @@ def _create_edge_id_particle_mapping(
     graph: MutableTransition[ParticleWithSpin, InteractionProperties],
     edge_ids: Iterable[int],
 ) -> Dict[int, str]:
-    return {i: graph.edge_props[i][0].name for i in edge_ids}
+    return {i: graph.states[i][0].name for i in edge_ids}

--- a/src/qrules/combinatorics.py
+++ b/src/qrules/combinatorics.py
@@ -24,9 +24,6 @@ from typing import (
     Union,
 )
 
-from attrs import field, frozen
-
-from qrules._implementers import implement_pretty_repr
 from qrules.particle import Particle, ParticleCollection
 
 from .particle import ParticleWithSpin
@@ -35,13 +32,8 @@ from .topology import MutableTransition, Topology, get_originating_node_list
 
 StateWithSpins = Tuple[str, Sequence[float]]
 StateDefinition = Union[str, StateWithSpins]
-
-
-@implement_pretty_repr
-@frozen
-class InitialFacts:
-    states: Dict[int, ParticleWithSpin] = field(factory=dict)
-    interactions: Dict[int, InteractionProperties] = field(factory=dict)
+InitialFacts = MutableTransition[ParticleWithSpin, InteractionProperties]
+"""A `.Transition` with only initial and final state information."""
 
 
 class _KinematicRepresentation:
@@ -268,7 +260,7 @@ def create_initial_facts(  # pylint: disable=too-many-locals
             kinematic_permutation, particle_db
         )
         edge_initial_facts.extend(
-            [InitialFacts(states=x) for x in spin_permutations]
+            [InitialFacts(topology, states=x) for x in spin_permutations]
         )
     return edge_initial_facts
 

--- a/src/qrules/combinatorics.py
+++ b/src/qrules/combinatorics.py
@@ -1,8 +1,8 @@
-"""Perform permutations on the edges of a `.StateTransitionGraph`.
+"""Perform permutations on the edges of a `.MutableTransition`.
 
-In a `.StateTransitionGraph`, the edges represent quantum states, while the
-nodes represent interactions. This module provides tools to permutate, modify
-or extract these edge and node properties.
+In a `.MutableTransition`, the edges represent quantum states, while the nodes
+represent interactions. This module provides tools to permutate, modify or
+extract these edge and node properties.
 """
 
 from collections import OrderedDict
@@ -31,7 +31,7 @@ from qrules.particle import Particle, ParticleCollection
 
 from .particle import ParticleWithSpin
 from .quantum_numbers import InteractionProperties, arange
-from .topology import StateTransitionGraph, Topology, get_originating_node_list
+from .topology import MutableTransition, Topology, get_originating_node_list
 
 StateWithSpins = Tuple[str, Sequence[float]]
 StateDefinition = Union[str, StateWithSpins]
@@ -168,7 +168,7 @@ def _get_kinematic_representation(
     r"""Group final or initial states by node, sorted by length of the group.
 
     The resulting sorted groups can be used to check whether two
-    `.StateTransitionGraph` instances are kinematically identical. For
+    `.MutableTransition` instances are kinematically identical. For
     instance, the following two graphs:
 
     .. code-block::
@@ -406,21 +406,19 @@ def _generate_spin_permutations(
 
 
 def __get_initial_state_edge_ids(
-    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
+    graph: MutableTransition[ParticleWithSpin, InteractionProperties],
 ) -> Iterable[int]:
     return graph.topology.incoming_edge_ids
 
 
 def __get_final_state_edge_ids(
-    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
+    graph: MutableTransition[ParticleWithSpin, InteractionProperties],
 ) -> Iterable[int]:
     return graph.topology.outgoing_edge_ids
 
 
 def match_external_edges(
-    graphs: List[
-        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
-    ],
+    graphs: List[MutableTransition[ParticleWithSpin, InteractionProperties]],
 ) -> None:
     if not isinstance(graphs, list):
         raise TypeError("graphs argument is not of type list")
@@ -434,12 +432,10 @@ def match_external_edges(
 
 
 def _match_external_edge_ids(  # pylint: disable=too-many-locals
-    graphs: List[
-        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
-    ],
+    graphs: List[MutableTransition[ParticleWithSpin, InteractionProperties]],
     ref_graph_id: int,
     external_edge_getter_function: Callable[
-        [StateTransitionGraph], Iterable[int]
+        [MutableTransition], Iterable[int]
     ],
 ) -> None:
     ref_graph = graphs[ref_graph_id]
@@ -475,17 +471,17 @@ def _match_external_edge_ids(  # pylint: disable=too-many-locals
 
 
 def perform_external_edge_identical_particle_combinatorics(
-    graph: StateTransitionGraph,
-) -> List[StateTransitionGraph]:
-    """Create combinatorics clones of the `.StateTransitionGraph`.
+    graph: MutableTransition,
+) -> List[MutableTransition]:
+    """Create combinatorics clones of the `.MutableTransition`.
 
     In case of identical particles in the initial or final state. Only
     identical particles, which do not enter or exit the same node allow for
     combinatorics!
     """
-    if not isinstance(graph, StateTransitionGraph):
+    if not isinstance(graph, MutableTransition):
         raise TypeError(
-            f"graph argument is not of type {StateTransitionGraph.__class__}"
+            f"graph argument is not of type {MutableTransition.__class__}"
         )
     temp_new_graphs = _external_edge_identical_particle_combinatorics(
         graph, __get_final_state_edge_ids
@@ -501,11 +497,11 @@ def perform_external_edge_identical_particle_combinatorics(
 
 
 def _external_edge_identical_particle_combinatorics(
-    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
+    graph: MutableTransition[ParticleWithSpin, InteractionProperties],
     external_edge_getter_function: Callable[
-        [StateTransitionGraph], Iterable[int]
+        [MutableTransition], Iterable[int]
     ],
-) -> List[StateTransitionGraph]:
+) -> List[MutableTransition]:
     # pylint: disable=too-many-locals
     new_graphs = [graph]
     edge_particle_mapping = _create_edge_id_particle_mapping(
@@ -561,7 +557,7 @@ def _calculate_swappings(id_mapping: Dict[int, int]) -> OrderedDict:
 
 
 def _create_edge_id_particle_mapping(
-    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
+    graph: MutableTransition[ParticleWithSpin, InteractionProperties],
     edge_ids: Iterable[int],
 ) -> Dict[int, str]:
     return {i: graph.edge_props[i][0].name for i in edge_ids}

--- a/src/qrules/combinatorics.py
+++ b/src/qrules/combinatorics.py
@@ -406,19 +406,21 @@ def _generate_spin_permutations(
 
 
 def __get_initial_state_edge_ids(
-    graph: StateTransitionGraph[ParticleWithSpin],
+    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
 ) -> Iterable[int]:
     return graph.topology.incoming_edge_ids
 
 
 def __get_final_state_edge_ids(
-    graph: StateTransitionGraph[ParticleWithSpin],
+    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
 ) -> Iterable[int]:
     return graph.topology.outgoing_edge_ids
 
 
 def match_external_edges(
-    graphs: List[StateTransitionGraph[ParticleWithSpin]],
+    graphs: List[
+        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ],
 ) -> None:
     if not isinstance(graphs, list):
         raise TypeError("graphs argument is not of type list")
@@ -432,7 +434,9 @@ def match_external_edges(
 
 
 def _match_external_edge_ids(  # pylint: disable=too-many-locals
-    graphs: List[StateTransitionGraph[ParticleWithSpin]],
+    graphs: List[
+        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ],
     ref_graph_id: int,
     external_edge_getter_function: Callable[
         [StateTransitionGraph], Iterable[int]
@@ -497,7 +501,7 @@ def perform_external_edge_identical_particle_combinatorics(
 
 
 def _external_edge_identical_particle_combinatorics(
-    graph: StateTransitionGraph[ParticleWithSpin],
+    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
     external_edge_getter_function: Callable[
         [StateTransitionGraph], Iterable[int]
     ],
@@ -557,6 +561,7 @@ def _calculate_swappings(id_mapping: Dict[int, int]) -> OrderedDict:
 
 
 def _create_edge_id_particle_mapping(
-    graph: StateTransitionGraph[ParticleWithSpin], edge_ids: Iterable[int]
+    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
+    edge_ids: Iterable[int],
 ) -> Dict[int, str]:
     return {i: graph.edge_props[i][0].name for i in edge_ids}

--- a/src/qrules/combinatorics.py
+++ b/src/qrules/combinatorics.py
@@ -559,8 +559,4 @@ def _calculate_swappings(id_mapping: Dict[int, int]) -> OrderedDict:
 def _create_edge_id_particle_mapping(
     graph: StateTransitionGraph[ParticleWithSpin], edge_ids: Iterable[int]
 ) -> Dict[int, str]:
-    return {
-        i: graph.get_edge_props(i)[0].name
-        for i in edge_ids
-        if graph.get_edge_props(i)
-    }
+    return {i: graph.edge_props[i][0].name for i in edge_ids}

--- a/src/qrules/combinatorics.py
+++ b/src/qrules/combinatorics.py
@@ -5,6 +5,7 @@ represent interactions. This module provides tools to permutate, modify or
 extract these edge and node properties.
 """
 
+import sys
 from collections import OrderedDict
 from copy import deepcopy
 from itertools import permutations
@@ -30,9 +31,16 @@ from .particle import ParticleWithSpin
 from .quantum_numbers import InteractionProperties, arange
 from .topology import MutableTransition, Topology, get_originating_node_list
 
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
 StateWithSpins = Tuple[str, Sequence[float]]
 StateDefinition = Union[str, StateWithSpins]
-InitialFacts = MutableTransition[ParticleWithSpin, InteractionProperties]
+InitialFacts: TypeAlias = (
+    "MutableTransition[ParticleWithSpin, InteractionProperties]"
+)
 """A `.Transition` with only initial and final state information."""
 
 
@@ -254,13 +262,13 @@ def create_initial_facts(  # pylint: disable=too-many-locals
         final_state=final_state,
         allowed_kinematic_groupings=allowed_kinematic_groupings,
     )
-    edge_initial_facts = []
+    edge_initial_facts: List[InitialFacts] = []
     for kinematic_permutation in kinematic_permutation_graphs:
         spin_permutations = _generate_spin_permutations(
             kinematic_permutation, particle_db
         )
         edge_initial_facts.extend(
-            [InitialFacts(topology, states=x) for x in spin_permutations]
+            [MutableTransition(topology, states=x) for x in spin_permutations]
         )
     return edge_initial_facts
 
@@ -398,19 +406,19 @@ def _generate_spin_permutations(
 
 
 def __get_initial_state_edge_ids(
-    graph: MutableTransition[ParticleWithSpin, InteractionProperties],
+    graph: "MutableTransition[ParticleWithSpin, InteractionProperties]",
 ) -> Iterable[int]:
     return graph.topology.incoming_edge_ids
 
 
 def __get_final_state_edge_ids(
-    graph: MutableTransition[ParticleWithSpin, InteractionProperties],
+    graph: "MutableTransition[ParticleWithSpin, InteractionProperties]",
 ) -> Iterable[int]:
     return graph.topology.outgoing_edge_ids
 
 
 def match_external_edges(
-    graphs: List[MutableTransition[ParticleWithSpin, InteractionProperties]],
+    graphs: "List[MutableTransition[ParticleWithSpin, InteractionProperties]]",
 ) -> None:
     if not isinstance(graphs, list):
         raise TypeError("graphs argument is not of type list")
@@ -424,11 +432,9 @@ def match_external_edges(
 
 
 def _match_external_edge_ids(  # pylint: disable=too-many-locals
-    graphs: List[MutableTransition[ParticleWithSpin, InteractionProperties]],
+    graphs: "List[MutableTransition[ParticleWithSpin, InteractionProperties]]",
     ref_graph_id: int,
-    external_edge_getter_function: Callable[
-        [MutableTransition], Iterable[int]
-    ],
+    external_edge_getter_function: "Callable[[MutableTransition], Iterable[int]]",
 ) -> None:
     ref_graph = graphs[ref_graph_id]
     # create external edge to particle mapping
@@ -489,7 +495,7 @@ def perform_external_edge_identical_particle_combinatorics(
 
 
 def _external_edge_identical_particle_combinatorics(
-    graph: MutableTransition[ParticleWithSpin, InteractionProperties],
+    graph: "MutableTransition[ParticleWithSpin, InteractionProperties]",
     external_edge_getter_function: Callable[
         [MutableTransition], Iterable[int]
     ],
@@ -549,7 +555,7 @@ def _calculate_swappings(id_mapping: Dict[int, int]) -> OrderedDict:
 
 
 def _create_edge_id_particle_mapping(
-    graph: MutableTransition[ParticleWithSpin, InteractionProperties],
+    graph: "MutableTransition[ParticleWithSpin, InteractionProperties]",
     edge_ids: Iterable[int],
 ) -> Dict[int, str]:
     return {i: graph.states[i][0].name for i in edge_ids}

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -139,7 +139,7 @@ def asdot(
         )
         return _dot.insert_graphviz_styling(dot, graphviz_attrs=figure_style)
     if isinstance(instance, ReactionInfo):
-        instance = instance.to_graphs()
+        instance = instance.transitions
     if isinstance(instance, abc.Iterable):
         dot = _dot.graph_list_to_dot(
             instance,

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -15,8 +15,8 @@ import attrs
 import yaml
 
 from qrules.particle import Particle, ParticleCollection
-from qrules.topology import MutableTransition, Topology
-from qrules.transition import ProblemSet, ReactionInfo, State, StateTransition
+from qrules.topology import Topology, Transition
+from qrules.transition import ProblemSet, ReactionInfo, State
 
 from . import _dict, _dot
 
@@ -27,15 +27,15 @@ def asdict(instance: object) -> dict:
         return _dict.from_particle(instance)
     if isinstance(instance, ParticleCollection):
         return _dict.from_particle_collection(instance)
-    if isinstance(instance, (ReactionInfo, State, StateTransition)):
+    if isinstance(instance, (ReactionInfo, State)):
         return attrs.asdict(
             instance,
             recurse=True,
             filter=lambda a, _: a.init,
             value_serializer=_dict._value_serializer,
         )
-    if isinstance(instance, MutableTransition):
-        return _dict.from_stg(instance)
+    if isinstance(instance, Transition):
+        return _dict.from_transition(instance)
     if isinstance(instance, Topology):
         return _dict.from_topology(instance)
     raise NotImplementedError(
@@ -53,7 +53,7 @@ def fromdict(definition: dict) -> object:
     if keys == {"transitions", "formalism"}:
         return _dict.build_reaction_info(definition)
     if keys == {"topology", "states", "interactions"}:
-        return _dict.build_state_transition(definition)
+        return _dict.build_transition(definition)
     if keys == __REQUIRED_TOPOLOGY_FIELDS:
         return _dict.build_topology(definition)
     raise NotImplementedError(f"Could not determine type from keys {keys}")
@@ -127,9 +127,7 @@ def asdot(
         edge_style = {}
     if node_style is None:
         node_style = {}
-    if isinstance(instance, StateTransition):
-        instance = instance.to_graph()
-    if isinstance(instance, (ProblemSet, MutableTransition, Topology)):
+    if isinstance(instance, (ProblemSet, Topology, Transition)):
         dot = _dot.graph_to_dot(
             instance,
             render_node=render_node,

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -15,7 +15,7 @@ import attrs
 import yaml
 
 from qrules.particle import Particle, ParticleCollection
-from qrules.topology import StateTransitionGraph, Topology
+from qrules.topology import MutableTransition, Topology
 from qrules.transition import ProblemSet, ReactionInfo, State, StateTransition
 
 from . import _dict, _dot
@@ -34,7 +34,7 @@ def asdict(instance: object) -> dict:
             filter=lambda a, _: a.init,
             value_serializer=_dict._value_serializer,
         )
-    if isinstance(instance, StateTransitionGraph):
+    if isinstance(instance, MutableTransition):
         return _dict.from_stg(instance)
     if isinstance(instance, Topology):
         return _dict.from_topology(instance)
@@ -87,13 +87,13 @@ def asdot(
     """Convert a `object` to a DOT language `str`.
 
     Only works for objects that can be represented as a graph, particularly a
-    `.StateTransitionGraph` or a `list` of `.StateTransitionGraph` instances.
+    `.MutableTransition` or a `list` of `.MutableTransition` instances.
 
     Args:
         instance: the input `object` that is to be rendered as DOT (graphviz)
             language.
 
-        strip_spin: Normally, each `.StateTransitionGraph` has a `.Particle`
+        strip_spin: Normally, each `.MutableTransition` has a `.Particle`
             with a spin projection on its edges. This option hides the
             projections, leaving only `.Particle` names on edges.
 
@@ -102,7 +102,7 @@ def asdot(
 
         render_node: Whether or not to render node ID (in the case of a
             `.Topology`) and/or node properties (in the case of a
-            `.StateTransitionGraph`). Meaning of the labels:
+            `.MutableTransition`). Meaning of the labels:
 
             - :math:`P`: parity prefactor
             - :math:`s`: tuple of **coupled spin** magnitude and its
@@ -131,7 +131,7 @@ def asdot(
         node_style = {}
     if isinstance(instance, StateTransition):
         instance = instance.to_graph()
-    if isinstance(instance, (ProblemSet, StateTransitionGraph, Topology)):
+    if isinstance(instance, (ProblemSet, MutableTransition, Topology)):
         dot = _dot.graph_to_dot(
             instance,
             render_node=render_node,

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -54,8 +54,6 @@ def fromdict(definition: dict) -> object:
         return _dict.build_reaction_info(definition)
     if keys == {"topology", "states", "interactions"}:
         return _dict.build_state_transition(definition)
-    if keys == {"topology", "edge_props", "node_props"}:
-        return _dict.build_stg(definition)
     if keys == __REQUIRED_TOPOLOGY_FIELDS:
         return _dict.build_topology(definition)
     raise NotImplementedError(f"Could not determine type from keys {keys}")

--- a/src/qrules/io/_dict.py
+++ b/src/qrules/io/_dict.py
@@ -37,7 +37,7 @@ def from_stg(graph: StateTransitionGraph[ParticleWithSpin]) -> dict:
     topology = graph.topology
     edge_props_def = {}
     for i in topology.edges:
-        particle, spin_projection = graph.get_edge_props(i)
+        particle, spin_projection = graph.edge_props[i]
         if isinstance(spin_projection, float) and spin_projection.is_integer():
             spin_projection = int(spin_projection)
         edge_props_def[i] = {
@@ -46,7 +46,7 @@ def from_stg(graph: StateTransitionGraph[ParticleWithSpin]) -> dict:
         }
     node_props_def = {}
     for i in topology.nodes:
-        node_prop = graph.get_node_props(i)
+        node_prop = graph.node_props[i]
         node_props_def[i] = attrs.asdict(
             node_prop, filter=lambda a, v: a.init and a.default != v
         )

--- a/src/qrules/io/_dict.py
+++ b/src/qrules/io/_dict.py
@@ -16,7 +16,7 @@ from qrules.particle import (
     Spin,
 )
 from qrules.quantum_numbers import InteractionProperties
-from qrules.topology import Edge, StateTransitionGraph, Topology
+from qrules.topology import Edge, MutableTransition, Topology
 from qrules.transition import ReactionInfo, State, StateTransition
 
 
@@ -34,7 +34,7 @@ def from_particle(particle: Particle) -> dict:
 
 
 def from_stg(
-    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    graph: MutableTransition[ParticleWithSpin, InteractionProperties]
 ) -> dict:
     topology = graph.topology
     edge_props_def = {}
@@ -120,7 +120,7 @@ def build_reaction_info(definition: dict) -> ReactionInfo:
 
 def build_stg(
     definition: dict,
-) -> StateTransitionGraph[ParticleWithSpin, InteractionProperties]:
+) -> MutableTransition[ParticleWithSpin, InteractionProperties]:
     topology = build_topology(definition["topology"])
     edge_props_def: Dict[int, dict] = definition["edge_props"]
     edge_props: Dict[int, ParticleWithSpin] = {}
@@ -135,7 +135,7 @@ def build_stg(
         int(i): InteractionProperties(**node_def)
         for i, node_def in node_props_def.items()
     }
-    return StateTransitionGraph(
+    return MutableTransition(
         topology=topology,
         edge_props=edge_props,
         node_props=node_props,

--- a/src/qrules/io/_dict.py
+++ b/src/qrules/io/_dict.py
@@ -96,7 +96,7 @@ def build_reaction_info(definition: dict) -> ReactionInfo:
 
 def build_transition(
     definition: dict,
-) -> FrozenTransition[State, InteractionProperties]:
+) -> "FrozenTransition[State, InteractionProperties]":
     topology = build_topology(definition["topology"])
     states_def: Dict[int, dict] = definition["states"]
     states: Dict[int, State] = {}

--- a/src/qrules/io/_dict.py
+++ b/src/qrules/io/_dict.py
@@ -33,7 +33,9 @@ def from_particle(particle: Particle) -> dict:
     )
 
 
-def from_stg(graph: StateTransitionGraph[ParticleWithSpin]) -> dict:
+def from_stg(
+    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+) -> dict:
     topology = graph.topology
     edge_props_def = {}
     for i in topology.edges:
@@ -116,7 +118,9 @@ def build_reaction_info(definition: dict) -> ReactionInfo:
     return ReactionInfo(transitions, formalism=definition["formalism"])
 
 
-def build_stg(definition: dict) -> StateTransitionGraph[ParticleWithSpin]:
+def build_stg(
+    definition: dict,
+) -> StateTransitionGraph[ParticleWithSpin, InteractionProperties]:
     topology = build_topology(definition["topology"])
     edge_props_def: Dict[int, dict] = definition["edge_props"]
     edge_props: Dict[int, ParticleWithSpin] = {}

--- a/src/qrules/io/_dict.py
+++ b/src/qrules/io/_dict.py
@@ -37,25 +37,25 @@ def from_stg(
     graph: MutableTransition[ParticleWithSpin, InteractionProperties]
 ) -> dict:
     topology = graph.topology
-    edge_props_def = {}
+    states_def = {}
     for i in topology.edges:
-        particle, spin_projection = graph.edge_props[i]
+        particle, spin_projection = graph.states[i]
         if isinstance(spin_projection, float) and spin_projection.is_integer():
             spin_projection = int(spin_projection)
-        edge_props_def[i] = {
+        states_def[i] = {
             "particle": from_particle(particle),
             "spin_projection": spin_projection,
         }
-    node_props_def = {}
+    interactions_def = {}
     for i in topology.nodes:
-        node_prop = graph.node_props[i]
-        node_props_def[i] = attrs.asdict(
+        node_prop = graph.interactions[i]
+        interactions_def[i] = attrs.asdict(
             node_prop, filter=lambda a, v: a.init and a.default != v
         )
     return {
         "topology": from_topology(topology),
-        "edge_props": edge_props_def,
-        "node_props": node_props_def,
+        "states": states_def,
+        "interactions": interactions_def,
     }
 
 
@@ -116,30 +116,6 @@ def build_reaction_info(definition: dict) -> ReactionInfo:
         for transition_def in definition["transitions"]
     ]
     return ReactionInfo(transitions, formalism=definition["formalism"])
-
-
-def build_stg(
-    definition: dict,
-) -> MutableTransition[ParticleWithSpin, InteractionProperties]:
-    topology = build_topology(definition["topology"])
-    edge_props_def: Dict[int, dict] = definition["edge_props"]
-    edge_props: Dict[int, ParticleWithSpin] = {}
-    for i, edge_def in edge_props_def.items():
-        particle = build_particle(edge_def["particle"])
-        spin_projection = float(edge_def["spin_projection"])
-        if spin_projection.is_integer():
-            spin_projection = int(spin_projection)
-        edge_props[int(i)] = (particle, spin_projection)
-    node_props_def: Dict[int, dict] = definition["node_props"]
-    node_props = {
-        int(i): InteractionProperties(**node_def)
-        for i, node_def in node_props_def.items()
-    }
-    return MutableTransition(
-        topology=topology,
-        edge_props=edge_props,
-        node_props=node_props,
-    )
 
 
 def build_state_transition(definition: dict) -> StateTransition:

--- a/src/qrules/io/_dict.py
+++ b/src/qrules/io/_dict.py
@@ -126,10 +126,7 @@ def build_topology(definition: dict) -> Topology:
     nodes = definition["nodes"]
     edges_def: Dict[int, dict] = definition["edges"]
     edges = {int(i): Edge(**edge_def) for i, edge_def in edges_def.items()}
-    return Topology(
-        edges=edges,
-        nodes=nodes,
-    )
+    return Topology(nodes, edges)
 
 
 def validate_particle_collection(instance: dict) -> None:

--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -161,7 +161,7 @@ def graph_list_to_dot(
             raise ValueError(
                 "Collapsed graphs cannot be rendered with node properties"
             )
-        graphs = _collapse_graphs(graphs)  # type: ignore[assignment]
+        graphs = _collapse_graphs(graphs)
     elif strip_spin:
         if render_node:
             stripped_graphs = []
@@ -173,9 +173,9 @@ def graph_list_to_dot(
                 stripped_graph = _strip_projections(graph)
                 if stripped_graph not in stripped_graphs:
                     stripped_graphs.append(stripped_graph)
-            graphs = stripped_graphs  # type: ignore[assignment]
+            graphs = stripped_graphs
         else:
-            graphs = _get_particle_graphs(graphs)  # type: ignore[assignment]
+            graphs = _get_particle_graphs(graphs)
     dot = ""
     if not isinstance(graphs, abc.Sequence):
         graphs = list(graphs)

--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -436,7 +436,7 @@ def __extract_priority(description: str) -> int:
 
 def _get_particle_graphs(
     graphs: Iterable[Transition[ParticleWithSpin, InteractionProperties]],
-) -> List[FrozenTransition[Particle, None]]:
+) -> "List[FrozenTransition[Particle, None]]":
     """Strip `list` of `.Transition` s of the spin projections.
 
     Extract a `list` of `.Transition` instances with only `.Particle` instances
@@ -470,10 +470,10 @@ def _get_particle_graphs(
 
 def _strip_projections(
     graph: Transition[Any, InteractionProperties],
-) -> FrozenTransition[Particle, InteractionProperties]:
+) -> "FrozenTransition[Particle, InteractionProperties]":
     if isinstance(graph, MutableTransition):
         transition = graph.freeze()
-    transition = cast(FrozenTransition[Any, InteractionProperties], graph)
+    transition = cast("FrozenTransition[Any, InteractionProperties]", graph)
     return transition.convert(
         state_converter=__to_particle,
         interaction_converter=lambda i: attrs.evolve(
@@ -494,9 +494,9 @@ def __to_particle(state: Any) -> Particle:
 
 def _collapse_graphs(
     graphs: Iterable[Transition[ParticleWithSpin, InteractionProperties]],
-) -> Tuple[FrozenTransition[Tuple[Particle, ...], None], ...]:
-    transition_groups = {
-        g.topology: MutableTransition[Set[Particle], None](
+) -> "Tuple[FrozenTransition[Tuple[Particle, ...], None], ...]":
+    transition_groups: "Dict[Topology, MutableTransition[Set[Particle], None]]" = {
+        g.topology: MutableTransition(
             g.topology,
             states={i: set() for i in g.topology.edges},
             interactions={i: None for i in g.topology.nodes},
@@ -512,11 +512,11 @@ def _collapse_graphs(
             else:
                 particle, _ = state
             group.states[state_id].add(particle)
-    particle_collection_graphs = []
+    collected_graphs: "List[FrozenTransition[Tuple[Particle, ...], None]]" = []
     for topology in sorted(transition_groups):
         group = transition_groups[topology]
-        particle_collection_graphs.append(
-            FrozenTransition[Tuple[Particle, ...], None](
+        collected_graphs.append(
+            FrozenTransition(
                 topology,
                 states={
                     i: tuple(sorted(particles, key=lambda p: p.name))
@@ -525,4 +525,4 @@ def _collapse_graphs(
                 interactions=group.interactions,
             )
         )
-    return tuple(particle_collection_graphs)
+    return tuple(collected_graphs)

--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -466,8 +466,10 @@ def __extract_priority(description: str) -> int:
 
 
 def _get_particle_graphs(
-    graphs: Iterable[StateTransitionGraph[ParticleWithSpin]],
-) -> List[StateTransitionGraph[Particle]]:
+    graphs: Iterable[
+        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ],
+) -> List[StateTransitionGraph[Particle, InteractionProperties]]:
     """Strip `list` of `.StateTransitionGraph` s of the spin projections.
 
     Extract a `list` of `.StateTransitionGraph` instances with only
@@ -475,7 +477,7 @@ def _get_particle_graphs(
 
     .. seealso:: :doc:`/usage/visualize`
     """
-    inventory: List[StateTransitionGraph[Particle]] = []
+    inventory: List[StateTransitionGraph[Particle, InteractionProperties]] = []
     for transition in graphs:
         if isinstance(transition, StateTransition):
             transition = transition.to_graph()
@@ -498,8 +500,8 @@ def _get_particle_graphs(
 
 
 def _strip_projections(
-    graph: StateTransitionGraph[ParticleWithSpin],
-) -> StateTransitionGraph[Particle]:
+    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
+) -> StateTransitionGraph[Particle, InteractionProperties]:
     if isinstance(graph, StateTransition):
         graph = graph.to_graph()
     new_edge_props = {}
@@ -514,7 +516,7 @@ def _strip_projections(
             new_node_props[node_id] = attrs.evolve(
                 node_props, l_projection=None, s_projection=None
             )
-    return StateTransitionGraph[Particle](
+    return StateTransitionGraph[Particle, InteractionProperties](
         topology=graph.topology,
         node_props=new_node_props,
         edge_props=new_edge_props,
@@ -522,11 +524,15 @@ def _strip_projections(
 
 
 def _collapse_graphs(
-    graphs: Iterable[StateTransitionGraph[ParticleWithSpin]],
-) -> List[StateTransitionGraph[ParticleCollection]]:
+    graphs: Iterable[
+        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ],
+) -> List[StateTransitionGraph[ParticleCollection, InteractionProperties]]:
     def merge_into(
-        graph: StateTransitionGraph[Particle],
-        merged_graph: StateTransitionGraph[ParticleCollection],
+        graph: StateTransitionGraph[Particle, InteractionProperties],
+        merged_graph: StateTransitionGraph[
+            ParticleCollection, InteractionProperties
+        ],
     ) -> None:
         if (
             graph.topology.intermediate_edge_ids
@@ -542,8 +548,10 @@ def _collapse_graphs(
                 other_particles += particle
 
     def is_same_shape(
-        graph: StateTransitionGraph[Particle],
-        merged_graph: StateTransitionGraph[ParticleCollection],
+        graph: StateTransitionGraph[Particle, InteractionProperties],
+        merged_graph: StateTransitionGraph[
+            ParticleCollection, InteractionProperties
+        ],
     ) -> bool:
         if graph.topology.edges != merged_graph.topology.edges:
             return False
@@ -559,7 +567,9 @@ def _collapse_graphs(
         return True
 
     particle_graphs = _get_particle_graphs(graphs)
-    inventory: List[StateTransitionGraph[ParticleCollection]] = []
+    inventory: List[
+        StateTransitionGraph[ParticleCollection, InteractionProperties]
+    ] = []
     for graph in particle_graphs:
         append_to_inventory = True
         for merged_graph in inventory:
@@ -573,7 +583,9 @@ def _collapse_graphs(
                 for edge_id in graph.topology.edges
             }
             inventory.append(
-                StateTransitionGraph[ParticleCollection](
+                StateTransitionGraph[
+                    ParticleCollection, InteractionProperties
+                ](
                     topology=graph.topology,
                     node_props={
                         i: graph.node_props[i] for i in graph.topology.nodes

--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -279,7 +279,7 @@ def __graph_to_dot_content(  # pylint: disable=too-many-branches,too-many-locals
                 from_node, to_node, label=label, graphviz_attrs=edge_style
             )
     if isinstance(graph, ProblemSet):
-        node_settings = graph.solving_settings.node_settings
+        node_settings = graph.solving_settings.interactions
         for node_id, settings in node_settings.items():
             node_label = ""
             if render_node:
@@ -344,13 +344,13 @@ def __get_edge_label(
     render_edge_id: bool,
 ) -> str:
     if isinstance(graph, GraphSettings):
-        edge_setting = graph.edge_settings.get(edge_id)
+        edge_setting = graph.states.get(edge_id)
         return ___render_edge_with_id(edge_id, edge_setting, render_edge_id)
     if isinstance(graph, InitialFacts):
         initial_fact = graph.states.get(edge_id)
         return ___render_edge_with_id(edge_id, initial_fact, render_edge_id)
     if isinstance(graph, ProblemSet):
-        edge_setting = graph.solving_settings.edge_settings.get(edge_id)
+        edge_setting = graph.solving_settings.states.get(edge_id)
         initial_fact = graph.initial_facts.states.get(edge_id)
         edge_property: Optional[Union[EdgeSettings, ParticleWithSpin]] = None
         if edge_setting:

--- a/src/qrules/particle.py
+++ b/src/qrules/particle.py
@@ -8,7 +8,7 @@ can be used stand-alone as a database of quantum numbers (see
 :doc:`/usage/particle`).
 
 The `.transition` module uses the properties of `Particle` instances when it
-computes which `.StateTransitionGraph` s are allowed between an initial state
+computes which `.MutableTransition` s are allowed between an initial state
 and final state.
 """
 

--- a/src/qrules/quantum_numbers.py
+++ b/src/qrules/quantum_numbers.py
@@ -169,7 +169,7 @@ def _to_optional_int(optional_int: Optional[int]) -> Optional[int]:
 class InteractionProperties:
     """Immutable data structure containing interaction properties.
 
-    Interactions are represented by a node on a `.StateTransitionGraph`. This
+    Interactions are represented by a node on a `.MutableTransition`. This
     class represents the properties that are carried collectively by the edges
     that this node connects.
 

--- a/src/qrules/solving.py
+++ b/src/qrules/solving.py
@@ -2,10 +2,10 @@
 """Functions to solve a particle reaction problem.
 
 This module is responsible for solving a particle reaction problem stated by a
-`.StateTransitionGraph` and corresponding `.GraphSettings`. The `.Solver`
-classes (e.g. :class:`.CSPSolver`) generate new quantum numbers (for example
-belonging to an intermediate state) and validate the decay processes with the
-rules formulated by the :mod:`.conservation_rules` module.
+`.MutableTransition` and corresponding `.GraphSettings`. The `.Solver` classes
+(e.g. :class:`.CSPSolver`) generate new quantum numbers (for example belonging
+to an intermediate state) and validate the decay processes with the rules
+formulated by the :mod:`.conservation_rules` module.
 """
 
 

--- a/src/qrules/solving.py
+++ b/src/qrules/solving.py
@@ -11,6 +11,7 @@ module.
 
 import inspect
 import logging
+import sys
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from copy import copy
@@ -57,6 +58,11 @@ from .quantum_numbers import (
 )
 from .topology import MutableTransition, Topology
 
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
 
 @implement_pretty_repr
 @define
@@ -89,11 +95,11 @@ class NodeSettings:
     interaction_strength: float = 1.0
 
 
-GraphSettings = MutableTransition[EdgeSettings, NodeSettings]
+GraphSettings: TypeAlias = "MutableTransition[EdgeSettings, NodeSettings]"
 """(Mutable) mapping of settings on a `.Topology`."""
-GraphElementProperties = MutableTransition[
-    GraphEdgePropertyMap, GraphNodePropertyMap
-]
+GraphElementProperties: TypeAlias = (
+    "MutableTransition[GraphEdgePropertyMap, GraphNodePropertyMap]"
+)
 """(Mutable) mapping of edge and node properties on a `.Topology`."""
 
 
@@ -116,9 +122,9 @@ class QNProblemSet:
         return self.initial_facts.topology
 
 
-QuantumNumberSolution = MutableTransition[
-    GraphEdgePropertyMap, GraphNodePropertyMap
-]
+QuantumNumberSolution: TypeAlias = (
+    "MutableTransition[GraphEdgePropertyMap, GraphNodePropertyMap]"
+)
 
 
 def _convert_violated_rules_to_names(
@@ -433,7 +439,7 @@ def validate_full_solution(problem_set: QNProblemSet) -> QNResult:
         )
     return QNResult(
         [
-            QuantumNumberSolution(
+            MutableTransition(
                 topology=problem_set.topology,
                 states=problem_set.initial_facts.states,
                 interactions=problem_set.initial_facts.interactions,
@@ -562,10 +568,10 @@ class CSPSolver(Solver):
                 result.extend(
                     validate_full_solution(
                         QNProblemSet(
-                            initial_facts=GraphElementProperties(
+                            initial_facts=MutableTransition(
                                 topology, states, interactions
                             ),
-                            solving_settings=GraphSettings(
+                            solving_settings=MutableTransition(
                                 topology,
                                 interactions={
                                     i: NodeSettings(conservation_rules=rules)
@@ -833,7 +839,7 @@ class CSPSolver(Solver):
                 else:
                     interactions[ele_id].update({qn_type: value})  # type: ignore[dict-item]
             converted_solutions.append(
-                QuantumNumberSolution(topology, states, interactions)
+                MutableTransition(topology, states, interactions)
             )
         return converted_solutions
 

--- a/src/qrules/solving.py
+++ b/src/qrules/solving.py
@@ -90,9 +90,11 @@ class NodeSettings:
 
 
 GraphSettings = MutableTransition[EdgeSettings, NodeSettings]
+"""(Mutable) mapping of settings on a `.Topology`."""
 GraphElementProperties = MutableTransition[
     GraphEdgePropertyMap, GraphNodePropertyMap
 ]
+"""(Mutable) mapping of edge and node properties on a `.Topology`."""
 
 
 @implement_pretty_repr
@@ -106,8 +108,8 @@ class QNProblemSet:
         and variable domains for nodes and edges of the :attr:`topology`.
     """
 
-    initial_facts: GraphElementProperties
-    solving_settings: GraphSettings
+    initial_facts: "GraphElementProperties"
+    solving_settings: "GraphSettings"
 
     @property
     def topology(self) -> Topology:

--- a/src/qrules/solving.py
+++ b/src/qrules/solving.py
@@ -99,8 +99,8 @@ class GraphSettings:
 @implement_pretty_repr
 @define
 class GraphElementProperties:
-    edge_props: Dict[int, GraphEdgePropertyMap] = field(factory=dict)
-    node_props: Dict[int, GraphNodePropertyMap] = field(factory=dict)
+    states: Dict[int, GraphEdgePropertyMap] = field(factory=dict)
+    interactions: Dict[int, GraphNodePropertyMap] = field(factory=dict)
 
 
 @implement_pretty_repr
@@ -326,12 +326,12 @@ def validate_full_solution(problem_set: QNProblemSet) -> QNResult:
     ) -> Dict[Type[NodeQuantumNumber], Scalar]:
         """Create variables for the quantum numbers of the specified node."""
         variables = {}
-        if node_id in problem_set.initial_facts.node_props:
-            node_props = problem_set.initial_facts.node_props[node_id]
-            variables = node_props
+        if node_id in problem_set.initial_facts.interactions:
+            interactions = problem_set.initial_facts.interactions[node_id]
+            variables = interactions
             for qn_type in qn_list:
-                if qn_type in node_props:
-                    variables[qn_type] = node_props[qn_type]
+                if qn_type in interactions:
+                    variables[qn_type] = interactions[qn_type]
         return variables
 
     def _create_edge_variables(
@@ -346,12 +346,12 @@ def validate_full_solution(problem_set: QNProblemSet) -> QNResult:
         """
         variables = []
         for edge_id in edge_ids:
-            if edge_id in problem_set.initial_facts.edge_props:
-                edge_props = problem_set.initial_facts.edge_props[edge_id]
+            if edge_id in problem_set.initial_facts.states:
+                states = problem_set.initial_facts.states[edge_id]
                 edge_vars = {}
                 for qn_type in qn_list:
-                    if qn_type in edge_props:
-                        edge_vars[qn_type] = edge_props[qn_type]
+                    if qn_type in states:
+                        edge_vars[qn_type] = states[qn_type]
                 variables.append(edge_vars)
         return variables
 
@@ -444,8 +444,8 @@ def validate_full_solution(problem_set: QNProblemSet) -> QNResult:
     return QNResult(
         [
             QuantumNumberSolution(
-                edge_quantum_numbers=problem_set.initial_facts.edge_props,
-                node_quantum_numbers=problem_set.initial_facts.node_props,
+                edge_quantum_numbers=problem_set.initial_facts.states,
+                node_quantum_numbers=problem_set.initial_facts.interactions,
             )
         ],
     )
@@ -548,8 +548,8 @@ class CSPSolver(Solver):
         else:
             full_particle_solutions = [
                 QuantumNumberSolution(
-                    node_quantum_numbers=problem_set.initial_facts.node_props,
-                    edge_quantum_numbers=problem_set.initial_facts.edge_props,
+                    node_quantum_numbers=problem_set.initial_facts.interactions,
+                    edge_quantum_numbers=problem_set.initial_facts.states,
                 )
             ]
 
@@ -560,17 +560,17 @@ class CSPSolver(Solver):
             # and combine results
             result = QNResult()
             for full_particle_solution in full_particle_solutions:
-                node_props = full_particle_solution.node_quantum_numbers
-                edge_props = full_particle_solution.edge_quantum_numbers
-                node_props.update(problem_set.initial_facts.node_props)
-                edge_props.update(problem_set.initial_facts.edge_props)
+                interactions = full_particle_solution.node_quantum_numbers
+                states = full_particle_solution.edge_quantum_numbers
+                interactions.update(problem_set.initial_facts.interactions)
+                states.update(problem_set.initial_facts.states)
                 result.extend(
                     validate_full_solution(
                         QNProblemSet(
                             topology=problem_set.topology,
                             initial_facts=GraphElementProperties(
-                                node_props=node_props,
-                                edge_props=edge_props,
+                                interactions=interactions,
+                                states=states,
                             ),
                             solving_settings=GraphSettings(
                                 node_settings={
@@ -755,11 +755,11 @@ class CSPSolver(Solver):
             {},
         )
 
-        if node_id in problem_set.initial_facts.node_props:
-            node_props = problem_set.initial_facts.node_props[node_id]
+        if node_id in problem_set.initial_facts.interactions:
+            interactions = problem_set.initial_facts.interactions[node_id]
             for qn_type in qn_list:
-                if qn_type in node_props:
-                    variables[1].update({qn_type: node_props[qn_type]})
+                if qn_type in interactions:
+                    variables[1].update({qn_type: interactions[qn_type]})
         else:
             node_settings = problem_set.solving_settings.node_settings[node_id]
             for qn_type in qn_list:
@@ -793,12 +793,12 @@ class CSPSolver(Solver):
 
         for edge_id in edge_ids:
             variables[1][edge_id] = {}
-            if edge_id in problem_set.initial_facts.edge_props:
-                edge_props = problem_set.initial_facts.edge_props[edge_id]
+            if edge_id in problem_set.initial_facts.states:
+                states = problem_set.initial_facts.states[edge_id]
                 for qn_type in qn_list:
-                    if qn_type in edge_props:
+                    if qn_type in states:
                         variables[1][edge_id].update(
-                            {qn_type: edge_props[qn_type]}
+                            {qn_type: states[qn_type]}
                         )
             else:
                 edge_settings = problem_set.solving_settings.edge_settings[

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -5,7 +5,7 @@ Responsible for building all possible topologies bases on basic user input:
 - number of initial state particles
 - number of final state particles
 
-The main interface is the `.StateTransitionGraph`.
+The main interface is the `.MutableTransition`.
 """
 
 import copy
@@ -170,7 +170,7 @@ def _to_frozenset(iterable: Iterable[int]) -> FrozenSet[int]:
 class Topology:
     """Directed Feynman-like graph without edge or node properties.
 
-    Forms the underlying topology of `StateTransitionGraph`. The graphs are
+    Forms the underlying topology of `MutableTransition`. The graphs are
     directed, meaning the edges are ingoing and outgoing to specific nodes
     (since feynman graphs also have a time axis). Note that a `Topology` is not
     strictly speaking a graph from graph theory, because it allows open edges,
@@ -665,7 +665,7 @@ def _cast_nodes(obj: Mapping[int, NodeType]) -> Dict[int, NodeType]:
 
 @implement_pretty_repr
 @define
-class StateTransitionGraph(Generic[EdgeType, NodeType]):
+class MutableTransition(Generic[EdgeType, NodeType]):
     """Graph class that resembles a frozen `.Topology` with properties.
 
     This class should contain the full information of a state transition from a
@@ -680,7 +680,7 @@ class StateTransitionGraph(Generic[EdgeType, NodeType]):
 
     def compare(
         self,
-        other: "StateTransitionGraph",
+        other: "MutableTransition",
         edge_comparator: Optional[Callable[[EdgeType, EdgeType], bool]] = None,
         node_comparator: Optional[Callable[[NodeType, NodeType], bool]] = None,
     ) -> bool:

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -812,7 +812,7 @@ class MutableTransition(Transition, Generic[EdgeType, NodeType]):
         if value2 is not None:
             self.states[edge_id1] = value2
 
-    def freeze(self) -> FrozenTransition[EdgeType, NodeType]:
+    def freeze(self) -> "FrozenTransition[EdgeType, NodeType]":
         return FrozenTransition(self.topology, self.states, self.interactions)
 
 

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -696,8 +696,10 @@ class MutableTransition(Generic[EdgeType, NodeType]):
     """
 
     topology: Topology = field(validator=instance_of(Topology))
-    states: Dict[int, EdgeType] = field(converter=_cast_states)
-    interactions: Dict[int, NodeType] = field(converter=_cast_interactions)
+    states: Dict[int, EdgeType] = field(converter=_cast_states, factory=dict)
+    interactions: Dict[int, NodeType] = field(
+        converter=_cast_interactions, factory=dict
+    )
 
     def compare(
         self,

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -655,6 +655,16 @@ EdgeType = TypeVar("EdgeType")
 """A `~typing.TypeVar` representing the type of edge properties."""
 
 
+def _cast_edges(obj: Mapping[int, EdgeType]) -> Dict[int, EdgeType]:
+    return dict(obj)
+
+
+def _cast_nodes(
+    obj: Mapping[int, InteractionProperties]
+) -> Dict[int, InteractionProperties]:
+    return dict(obj)
+
+
 @implement_pretty_repr()
 @define
 class StateTransitionGraph(Generic[EdgeType]):
@@ -667,14 +677,8 @@ class StateTransitionGraph(Generic[EdgeType]):
     """
 
     topology: Topology = field(validator=instance_of(Topology))
-    node_props: Dict[int, InteractionProperties]
-    edge_props: Dict[int, EdgeType]
-
-    def get_node_props(self, node_id: int) -> InteractionProperties:
-        return self.node_props[node_id]
-
-    def get_edge_props(self, edge_id: int) -> EdgeType:
-        return self.edge_props[edge_id]
+    node_props: Dict[int, InteractionProperties] = field(converter=_cast_nodes)
+    edge_props: Dict[int, EdgeType] = field(converter=_cast_edges)
 
     def evolve(
         self,

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -624,7 +624,7 @@ def create_isobar_topologies(
         number_of_initial_edges=1,
         number_of_final_edges=number_of_final_states,
     )
-    return tuple(topologies)
+    return tuple(sorted(topologies))
 
 
 def create_n_body_topology(

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -655,6 +655,20 @@ NodeType = TypeVar("NodeType")
 """A `~typing.TypeVar` representing the type of node properties."""
 
 
+@implement_pretty_repr()
+@frozen(order=True)
+class FrozenTransition(Generic[EdgeType, NodeType]):
+    """Defines a frozen mapping of edge and node properties on a `Topology`."""
+
+    topology: Topology = field(validator=instance_of(Topology))
+    edge_props: FrozenDict[int, NodeType] = field(converter=FrozenDict)
+    node_props: FrozenDict[int, EdgeType] = field(converter=FrozenDict)
+
+    def __attrs_post_init__(self) -> None:
+        _assert_all_defined(self.topology.nodes, self.node_props)
+        _assert_all_defined(self.topology.edges, self.edge_props)
+
+
 def _cast_edges(obj: Mapping[int, EdgeType]) -> Dict[int, EdgeType]:
     return dict(obj)
 
@@ -714,7 +728,6 @@ class MutableTransition(Generic[EdgeType, NodeType]):
             self.edge_props[edge_id1] = value2
 
 
-# pyright: reportUnusedFunction=false
 def _assert_all_defined(items: Iterable, properties: Iterable) -> None:
     existing = set(items)
     defined = set(properties)

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -55,24 +55,22 @@ if TYPE_CHECKING:
         PrettyPrinter = Any
 
 
-class Comparable(Protocol):
+class _Comparable(Protocol):
     @abstractmethod
     def __lt__(self, other: Any) -> bool:
         ...
 
 
-KeyType = TypeVar("KeyType", bound=Comparable)
-"""Type the keys of the `~typing.Mapping`, see `~typing.KeysView`."""
-ValueType = TypeVar("ValueType")
-"""Type the value of the `~typing.Mapping`, see `~typing.ValuesView`."""
+KT = TypeVar("KT", bound=_Comparable)
+VT = TypeVar("VT")
 
 
 @total_ordering
 class FrozenDict(  # pylint: disable=too-many-ancestors
-    abc.Hashable, abc.Mapping, Generic[KeyType, ValueType]
+    abc.Hashable, abc.Mapping, Generic[KT, VT]
 ):
     def __init__(self, mapping: Optional[Mapping] = None):
-        self.__mapping: Dict[KeyType, ValueType] = {}
+        self.__mapping: Dict[KT, VT] = {}
         if mapping is not None:
             self.__mapping = dict(mapping)
         self.__hash = hash(None)
@@ -98,13 +96,13 @@ class FrozenDict(  # pylint: disable=too-many-ancestors
             p.breakable()
             p.text("})")
 
-    def __iter__(self) -> Iterator[KeyType]:
+    def __iter__(self) -> Iterator[KT]:
         return iter(self.__mapping)
 
     def __len__(self) -> int:
         return len(self.__mapping)
 
-    def __getitem__(self, key: KeyType) -> ValueType:
+    def __getitem__(self, key: KT) -> VT:
         return self.__mapping[key]
 
     def __gt__(self, other: Any) -> bool:
@@ -121,19 +119,19 @@ class FrozenDict(  # pylint: disable=too-many-ancestors
     def __hash__(self) -> int:
         return self.__hash
 
-    def keys(self) -> KeysView[KeyType]:
+    def keys(self) -> KeysView[KT]:
         return self.__mapping.keys()
 
-    def items(self) -> ItemsView[KeyType, ValueType]:
+    def items(self) -> ItemsView[KT, VT]:
         return self.__mapping.items()
 
-    def values(self) -> ValuesView[ValueType]:
+    def values(self) -> ValuesView[VT]:
         return self.__mapping.values()
 
 
 def _convert_mapping_to_sorted_tuple(
-    mapping: Mapping[KeyType, ValueType],
-) -> Tuple[Tuple[KeyType, ValueType], ...]:
+    mapping: Mapping[KT, VT],
+) -> Tuple[Tuple[KT, VT], ...]:
     return tuple((key, mapping[key]) for key in sorted(mapping.keys()))
 
 
@@ -651,11 +649,7 @@ def _attach_node_to_edges(
 
 
 EdgeType = TypeVar("EdgeType")
-"""A `~typing.TypeVar` representing the type of edge properties."""
 NodeType = TypeVar("NodeType")
-"""A `~typing.TypeVar` representing the type of node properties."""
-
-
 NewEdgeType = TypeVar("NewEdgeType")
 NewNodeType = TypeVar("NewNodeType")
 

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -675,6 +675,21 @@ class FrozenTransition(Generic[EdgeType, NodeType]):
         _assert_all_defined(self.topology.nodes, self.interactions)
         _assert_all_defined(self.topology.edges, self.states)
 
+    @property
+    def initial_states(self) -> Dict[int, EdgeType]:
+        return self.filter_states(self.topology.incoming_edge_ids)
+
+    @property
+    def final_states(self) -> Dict[int, EdgeType]:
+        return self.filter_states(self.topology.outgoing_edge_ids)
+
+    @property
+    def intermediate_states(self) -> Dict[int, EdgeType]:
+        return self.filter_states(self.topology.intermediate_edge_ids)
+
+    def filter_states(self, edge_ids: Iterable[int]) -> Dict[int, EdgeType]:
+        return {i: self.states[i] for i in edge_ids}
+
 
 def _cast_states(obj: Mapping[int, EdgeType]) -> Dict[int, EdgeType]:
     return dict(obj)

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -43,9 +43,9 @@ from attrs.validators import instance_of
 from qrules._implementers import implement_pretty_repr
 
 if sys.version_info >= (3, 8):
-    from typing import Protocol
+    from typing import Protocol, runtime_checkable
 else:
-    from typing_extensions import Protocol
+    from typing_extensions import Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     try:
@@ -653,6 +653,13 @@ EdgeType = TypeVar("EdgeType")
 """A `~typing.TypeVar` representing the type of edge properties."""
 NodeType = TypeVar("NodeType")
 """A `~typing.TypeVar` representing the type of node properties."""
+
+
+@runtime_checkable
+class Transition(Protocol[EdgeType, NodeType]):
+    topology: Topology
+    states: Dict[int, EdgeType]
+    interactions: Dict[int, NodeType]
 
 
 @implement_pretty_repr

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -42,8 +42,6 @@ from attrs.validators import instance_of
 
 from qrules._implementers import implement_pretty_repr
 
-from .quantum_numbers import InteractionProperties
-
 if sys.version_info >= (3, 8):
     from typing import Protocol
 else:
@@ -653,21 +651,21 @@ def _attach_node_to_edges(
 
 EdgeType = TypeVar("EdgeType")
 """A `~typing.TypeVar` representing the type of edge properties."""
+NodeType = TypeVar("NodeType")
+"""A `~typing.TypeVar` representing the type of node properties."""
 
 
 def _cast_edges(obj: Mapping[int, EdgeType]) -> Dict[int, EdgeType]:
     return dict(obj)
 
 
-def _cast_nodes(
-    obj: Mapping[int, InteractionProperties]
-) -> Dict[int, InteractionProperties]:
+def _cast_nodes(obj: Mapping[int, NodeType]) -> Dict[int, NodeType]:
     return dict(obj)
 
 
-@implement_pretty_repr()
+@implement_pretty_repr
 @define
-class StateTransitionGraph(Generic[EdgeType]):
+class StateTransitionGraph(Generic[EdgeType, NodeType]):
     """Graph class that resembles a frozen `.Topology` with properties.
 
     This class should contain the full information of a state transition from a
@@ -677,16 +675,14 @@ class StateTransitionGraph(Generic[EdgeType]):
     """
 
     topology: Topology = field(validator=instance_of(Topology))
-    node_props: Dict[int, InteractionProperties] = field(converter=_cast_nodes)
+    node_props: Dict[int, NodeType] = field(converter=_cast_nodes)
     edge_props: Dict[int, EdgeType] = field(converter=_cast_edges)
 
     def compare(
         self,
         other: "StateTransitionGraph",
         edge_comparator: Optional[Callable[[EdgeType, EdgeType], bool]] = None,
-        node_comparator: Optional[
-            Callable[[InteractionProperties, InteractionProperties], bool]
-        ] = None,
+        node_comparator: Optional[Callable[[NodeType, NodeType], bool]] = None,
     ) -> bool:
         if self.topology != other.topology:
             return False

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -376,7 +376,7 @@ def get_originating_node_list(
     ]
 
 
-@define(kw_only=True)
+@define
 class MutableTopology:
     edges: Dict[int, Edge] = field(factory=dict, converter=dict)
     nodes: Set[int] = field(factory=set, converter=set)

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -680,34 +680,6 @@ class StateTransitionGraph(Generic[EdgeType]):
     node_props: Dict[int, InteractionProperties] = field(converter=_cast_nodes)
     edge_props: Dict[int, EdgeType] = field(converter=_cast_edges)
 
-    def evolve(
-        self,
-        node_props: Optional[Dict[int, InteractionProperties]] = None,
-        edge_props: Optional[Dict[int, EdgeType]] = None,
-    ) -> "StateTransitionGraph[EdgeType]":
-        """Changes the node and edge properties of a graph instance.
-
-        Since a `.StateTransitionGraph` is frozen (cannot be modified), the
-        evolve function will also create a shallow copy the properties.
-        """
-        new_node_props = copy.copy(self.node_props)
-        if node_props:
-            _assert_not_overdefined(self.topology.nodes, node_props)
-            for node_id, node_prop in node_props.items():
-                new_node_props[node_id] = node_prop
-
-        new_edge_props = copy.copy(self.edge_props)
-        if edge_props:
-            _assert_not_overdefined(self.topology.edges, edge_props)
-            for edge_id, edge_prop in edge_props.items():
-                new_edge_props[edge_id] = edge_prop
-
-        return StateTransitionGraph[EdgeType](
-            topology=self.topology,
-            node_props=new_node_props,
-            edge_props=new_edge_props,
-        )
-
     def compare(
         self,
         other: "StateTransitionGraph",
@@ -757,6 +729,7 @@ def _assert_all_defined(items: Iterable, properties: Iterable) -> None:
         )
 
 
+# pyright: reportUnusedFunction=false
 def _assert_not_overdefined(items: Iterable, properties: Iterable) -> None:
     existing = set(items)
     defined = set(properties)

--- a/src/qrules/topology.py
+++ b/src/qrules/topology.py
@@ -377,7 +377,7 @@ def get_originating_node_list(
 
 
 @define(kw_only=True)
-class _MutableTopology:
+class MutableTopology:
     edges: Dict[int, Edge] = field(factory=dict, converter=dict)
     nodes: Set[int] = field(factory=set, converter=set)
 
@@ -506,12 +506,12 @@ class SimpleStateTransitionTopologyBuilder:
 
         logging.info("building topology graphs...")
         # result list
-        graph_tuple_list: List[Tuple[_MutableTopology, List[int]]] = []
+        graph_tuple_list: List[Tuple[MutableTopology, List[int]]] = []
         # create seed graph
-        seed_graph = _MutableTopology()
+        seed_graph = MutableTopology()
         current_open_end_edges = list(range(number_of_initial_edges))
         seed_graph.add_edges(current_open_end_edges)
-        extendable_graph_list: List[Tuple[_MutableTopology, List[int]]] = [
+        extendable_graph_list: List[Tuple[MutableTopology, List[int]]] = [
             (seed_graph, current_open_end_edges)
         ]
 
@@ -540,9 +540,9 @@ class SimpleStateTransitionTopologyBuilder:
         return tuple(topologies)
 
     def _extend_graph(
-        self, pair: Tuple[_MutableTopology, Sequence[int]]
-    ) -> List[Tuple[_MutableTopology, List[int]]]:
-        extended_graph_list: List[Tuple[_MutableTopology, List[int]]] = []
+        self, pair: Tuple[MutableTopology, Sequence[int]]
+    ) -> List[Tuple[MutableTopology, List[int]]]:
+        extended_graph_list: List[Tuple[MutableTopology, List[int]]] = []
 
         topology, current_open_end_edges = pair
 
@@ -619,10 +619,10 @@ def create_n_body_topology(
 
 
 def _attach_node_to_edges(
-    graph: Tuple[_MutableTopology, Sequence[int]],
+    graph: Tuple[MutableTopology, Sequence[int]],
     interaction_node: InteractionNode,
     ingoing_edge_ids: Iterable[int],
-) -> Tuple[_MutableTopology, List[int]]:
+) -> Tuple[MutableTopology, List[int]]:
     temp_graph = copy.deepcopy(graph[0])
     new_open_end_lines = list(copy.deepcopy(graph[1]))
 

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -217,7 +217,7 @@ def _group_by_strength(
     )
     for problem_set in problem_sets:
         strength = calculate_strength(
-            problem_set.solving_settings.node_settings
+            problem_set.solving_settings.interactions
         )
         strength_sorted_problem_sets[strength].append(problem_set)
     return strength_sorted_problem_sets
@@ -464,11 +464,11 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
 
         graph_settings: List[GraphSettings] = [
             GraphSettings(
-                edge_settings={
+                states={
                     edge_id: create_edge_settings(edge_id)
                     for edge_id in topology.edges
                 },
-                node_settings={},
+                interactions={},
             )
         ]
 
@@ -515,7 +515,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             for temp_setting in temp_graph_settings:
                 for int_type in interaction_types:
                     updated_setting = deepcopy(temp_setting)
-                    updated_setting.node_settings[node_id] = deepcopy(
+                    updated_setting.interactions[node_id] = deepcopy(
                         self.interaction_type_settings[int_type][1]
                     )
                     graph_settings.append(updated_setting)

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -169,19 +169,14 @@ class _SolutionContainer:
 @implement_pretty_repr
 @define
 class ProblemSet:
-    """Particle reaction problem set, defined as a graph like data structure.
-
-    Args:
-        topology: `.Topology` that contains the structure of the reaction.
-        initial_facts: `.InitialFacts` that contain the info of initial and
-          final state in connection with the topology.
-        solving_settings: Solving related settings such as the conservation
-          rules and the quantum number domains.
-    """
+    """Particle reaction problem set as a graph-like data structure."""
 
     topology: Topology
-    initial_facts: InitialFacts
-    solving_settings: GraphSettings
+    """`.Topology` over which the problem set is defined."""
+    initial_facts: "InitialFacts"
+    """Information about the initial and final state."""
+    solving_settings: "GraphSettings"
+    """Solving settings, such as conservation rules and QN-domains."""
 
     def to_qn_problem_set(self) -> QNProblemSet:
         interactions = {
@@ -412,7 +407,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         return _group_by_strength(problem_sets)
 
     def __determine_graph_settings(
-        self, topology: Topology, initial_facts: InitialFacts
+        self, topology: Topology, initial_facts: "InitialFacts"
     ) -> List[GraphSettings]:
         # pylint: disable=too-many-locals
         def create_intermediate_edge_qn_domains() -> Dict:

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -137,9 +137,9 @@ class ExecutionInfo:
 class _SolutionContainer:
     """Defines a result of a `.ProblemSet`."""
 
-    solutions: List[StateTransitionGraph[ParticleWithSpin]] = field(
-        factory=list
-    )
+    solutions: List[
+        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ] = field(factory=list)
     execution_info: ExecutionInfo = field(default=ExecutionInfo())
 
     def __attrs_post_init__(self) -> None:
@@ -653,7 +653,9 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         """
         solutions = []
         for solution in qn_result.solutions:
-            graph = StateTransitionGraph[ParticleWithSpin](
+            graph = StateTransitionGraph[
+                ParticleWithSpin, InteractionProperties
+            ](
                 topology=topology,
                 node_props={
                     i: create_interaction_properties(x)
@@ -691,9 +693,9 @@ def _safe_wrap_list(
 
 
 def _match_final_state_ids(
-    graph: StateTransitionGraph[ParticleWithSpin],
+    graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
     state_definition: Sequence[StateDefinition],
-) -> StateTransitionGraph[ParticleWithSpin]:
+) -> StateTransitionGraph[ParticleWithSpin, InteractionProperties]:
     """Temporary fix to https://github.com/ComPWA/qrules/issues/143."""
     particle_names = _strip_spin(state_definition)
     name_to_id = {name: i for i, name in enumerate(particle_names)}
@@ -746,7 +748,7 @@ class StateTransition:
 
     @staticmethod
     def from_graph(
-        graph: StateTransitionGraph[ParticleWithSpin],
+        graph: StateTransitionGraph[ParticleWithSpin, InteractionProperties],
     ) -> "StateTransition":
         return StateTransition(
             topology=graph.topology,
@@ -758,8 +760,10 @@ class StateTransition:
             ),
         )
 
-    def to_graph(self) -> StateTransitionGraph[ParticleWithSpin]:
-        return StateTransitionGraph[ParticleWithSpin](
+    def to_graph(
+        self,
+    ) -> StateTransitionGraph[ParticleWithSpin, InteractionProperties]:
+        return StateTransitionGraph[ParticleWithSpin, InteractionProperties](
             topology=self.topology,
             edge_props={
                 i: (state.particle, state.spin_projection)
@@ -831,13 +835,17 @@ class ReactionInfo:
 
     @staticmethod
     def from_graphs(
-        graphs: Iterable[StateTransitionGraph[ParticleWithSpin]],
+        graphs: Iterable[
+            StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+        ],
         formalism: str,
     ) -> "ReactionInfo":
         transitions = [StateTransition.from_graph(g) for g in graphs]
         return ReactionInfo(transitions, formalism)
 
-    def to_graphs(self) -> List[StateTransitionGraph[ParticleWithSpin]]:
+    def to_graphs(
+        self,
+    ) -> List[StateTransitionGraph[ParticleWithSpin, InteractionProperties]]:
         return [transition.to_graph() for transition in self.transitions]
 
     def group_by_topology(self) -> Dict[Topology, List[StateTransition]]:

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -6,11 +6,9 @@ from copy import copy, deepcopy
 from enum import Enum, auto
 from multiprocessing import Pool
 from typing import (
-    Collection,
     Dict,
     Iterable,
     List,
-    Mapping,
     Optional,
     Sequence,
     Set,
@@ -76,6 +74,7 @@ from .topology import (
     FrozenDict,
     StateTransitionGraph,
     Topology,
+    _assert_all_defined,
     create_isobar_topologies,
     create_n_body_topology,
 )
@@ -742,8 +741,8 @@ class StateTransition:
     )
 
     def __attrs_post_init__(self) -> None:
-        _assert_defined(self.topology.edges, self.states)
-        _assert_defined(self.topology.nodes, self.interactions)
+        _assert_all_defined(self.topology.edges, self.states)
+        _assert_all_defined(self.topology.nodes, self.interactions)
 
     @staticmethod
     def from_graph(
@@ -790,16 +789,6 @@ class StateTransition:
     @property
     def particles(self) -> Dict[int, Particle]:
         return {i: edge_prop.particle for i, edge_prop in self.states.items()}
-
-
-def _assert_defined(items: Collection, properties: Mapping) -> None:
-    existing = set(items)
-    defined = set(properties)
-    if existing & defined != existing:
-        raise ValueError(
-            "Some items have no property assigned to them."
-            f" Available items: {existing}, items with property: {defined}"
-        )
 
 
 def _sort_tuple(

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -633,7 +633,11 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             _match_final_state_ids(graph, self.final_state)
             for graph in final_solutions
         ]
-        return ReactionInfo.from_graphs(final_solutions, self.formalism)
+        transitions = [
+            graph.freeze().convert(lambda s: State(*s))
+            for graph in final_solutions
+        ]
+        return ReactionInfo(transitions, self.formalism)
 
     def _solve(
         self, qn_problem_set: QNProblemSet
@@ -768,32 +772,6 @@ class ReactionInfo:
             for state in transition.intermediate_states.values()
         }
         return ParticleCollection(particles)
-
-    @staticmethod
-    def from_graphs(
-        graphs: Iterable[
-            MutableTransition[ParticleWithSpin, InteractionProperties]
-        ],
-        formalism: str,
-    ) -> "ReactionInfo":
-        transitions = [
-            g.freeze().convert(state_converter=lambda state: State(*state))
-            for g in graphs
-        ]
-        return ReactionInfo(transitions, formalism)
-
-    def to_graphs(
-        self,
-    ) -> List[MutableTransition[ParticleWithSpin, InteractionProperties]]:
-        return [
-            transition.convert(
-                state_converter=lambda state: (
-                    state.particle,
-                    state.spin_projection,
-                )
-            ).unfreeze()
-            for transition in self.transitions
-        ]
 
     def group_by_topology(self) -> Dict[Topology, List[StateTransition]]:
         groupings = defaultdict(list)

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -173,7 +173,7 @@ class ProblemSet:
 
     Args:
         topology: `.Topology` that contains the structure of the reaction.
-        initial_facts: `~.InitialFacts` that contain the info of initial and
+        initial_facts: `.InitialFacts` that contain the info of initial and
           final state in connection with the topology.
         solving_settings: Solving related settings such as the conservation
           rules and the quantum number domains.
@@ -193,9 +193,8 @@ class ProblemSet:
             for k, v in self.initial_facts.states.items()
         }
         return QNProblemSet(
-            topology=self.topology,
             initial_facts=GraphElementProperties(
-                interactions=interactions, states=states
+                self.topology, states, interactions
             ),
             solving_settings=self.solving_settings,
         )
@@ -464,11 +463,11 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
 
         graph_settings: List[GraphSettings] = [
             GraphSettings(
+                topology,
                 states={
                     edge_id: create_edge_settings(edge_id)
                     for edge_id in topology.edges
                 },
-                interactions={},
             )
         ]
 

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -698,17 +698,17 @@ def _match_final_state_ids(
     particle_names = _strip_spin(state_definition)
     name_to_id = {name: i for i, name in enumerate(particle_names)}
     id_remapping = {
-        name_to_id[graph.get_edge_props(i)[0].name]: i
+        name_to_id[graph.edge_props[i][0].name]: i
         for i in graph.topology.outgoing_edge_ids
     }
     new_topology = graph.topology.relabel_edges(id_remapping)
     return StateTransitionGraph(
         new_topology,
         edge_props={
-            i: graph.get_edge_props(id_remapping.get(i, i))
+            i: graph.edge_props[id_remapping.get(i, i)]
             for i in graph.topology.edges
         },
-        node_props={i: graph.get_node_props(i) for i in graph.topology.nodes},
+        node_props={i: graph.node_props[i] for i in graph.topology.nodes},
     )
 
 
@@ -751,13 +751,10 @@ class StateTransition:
         return StateTransition(
             topology=graph.topology,
             states=FrozenDict(
-                {
-                    i: State(*graph.get_edge_props(i))
-                    for i in graph.topology.edges
-                }
+                {i: State(*graph.edge_props[i]) for i in graph.topology.edges}
             ),
             interactions=FrozenDict(
-                {i: graph.get_node_props(i) for i in graph.topology.nodes}
+                {i: graph.node_props[i] for i in graph.topology.nodes}
             ),
         )
 

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -657,11 +657,11 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                 topology=topology,
                 interactions={
                     i: create_interaction_properties(x)
-                    for i, x in solution.node_quantum_numbers.items()
+                    for i, x in solution.interactions.items()
                 },
                 states={
                     i: create_particle(x, self.__particles)
-                    for i, x in solution.edge_quantum_numbers.items()
+                    for i, x in solution.states.items()
                 },
             )
             solutions.append(graph)

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -2,8 +2,6 @@ import pytest
 
 import qrules
 from qrules.combinatorics import _create_edge_id_particle_mapping
-from qrules.particle import ParticleWithSpin
-from qrules.topology import StateTransitionGraph
 
 
 @pytest.mark.parametrize(
@@ -62,7 +60,7 @@ def test_id_to_particle_mappings(particle_database):
     assert len(reaction.transitions) == 4
     iter_transitions = iter(reaction.transitions)
     first_transition = next(iter_transitions)
-    graph: StateTransitionGraph[ParticleWithSpin] = first_transition.to_graph()
+    graph = first_transition.to_graph()
     ref_mapping_fs = _create_edge_id_particle_mapping(
         graph, graph.topology.outgoing_edge_ids
     )

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -60,7 +60,9 @@ def test_id_to_particle_mappings(particle_database):
     assert len(reaction.transitions) == 4
     iter_transitions = iter(reaction.transitions)
     first_transition = next(iter_transitions)
-    graph = first_transition.to_graph()
+    graph = first_transition.convert(
+        lambda s: (s.particle, s.spin_projection)
+    ).unfreeze()
     ref_mapping_fs = _create_edge_id_particle_mapping(
         graph, graph.topology.outgoing_edge_ids
     )
@@ -68,7 +70,9 @@ def test_id_to_particle_mappings(particle_database):
         graph, graph.topology.incoming_edge_ids
     )
     for transition in iter_transitions:
-        graph = transition.to_graph()
+        graph = transition.convert(
+            lambda s: (s.particle, s.spin_projection)
+        ).unfreeze()
         assert ref_mapping_fs == _create_edge_id_particle_mapping(
             graph, graph.topology.outgoing_edge_ids
         )

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -208,10 +208,10 @@ def test_collapse_graphs(
     particle_database: ParticleCollection,
 ):
     pdg = particle_database
-    particle_graphs = _get_particle_graphs(reaction.to_graphs())
+    particle_graphs = _get_particle_graphs(reaction.to_graphs())  # type: ignore[arg-type]
     assert len(particle_graphs) == 2
 
-    collapsed_graphs = _collapse_graphs(reaction.to_graphs())
+    collapsed_graphs = _collapse_graphs(reaction.to_graphs())  # type: ignore[arg-type]
     assert len(collapsed_graphs) == 1
     graph = next(iter(collapsed_graphs))
     edge_id = next(iter(graph.topology.intermediate_edge_ids))
@@ -226,7 +226,7 @@ def test_get_particle_graphs(
     reaction: ReactionInfo, particle_database: ParticleCollection
 ):
     pdg = particle_database
-    graphs = _get_particle_graphs(reaction.to_graphs())
+    graphs = _get_particle_graphs(reaction.to_graphs())  # type: ignore[arg-type]
     assert len(graphs) == 2
     assert graphs[0].states[3] == pdg["f(0)(980)"]
     assert graphs[1].states[3] == pdg["f(0)(1500)"]

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -215,7 +215,7 @@ def test_collapse_graphs(
     graph = next(iter(collapsed_graphs))
     edge_id = next(iter(graph.topology.intermediate_edge_ids))
     f_resonances = pdg.filter(lambda p: p.name in ["f(0)(980)", "f(0)(1500)"])
-    intermediate_states = graph.edge_props[edge_id]
+    intermediate_states = graph.states[edge_id]
     assert isinstance(intermediate_states, ParticleCollection)
     assert intermediate_states == f_resonances
 
@@ -226,11 +226,11 @@ def test_get_particle_graphs(
     pdg = particle_database
     graphs = _get_particle_graphs(reaction.to_graphs())
     assert len(graphs) == 2
-    assert graphs[0].edge_props[3] == pdg["f(0)(980)"]
-    assert graphs[1].edge_props[3] == pdg["f(0)(1500)"]
+    assert graphs[0].states[3] == pdg["f(0)(980)"]
+    assert graphs[1].states[3] == pdg["f(0)(1500)"]
     assert len(graphs[0].topology.edges) == 5
     for i in range(-1, 3):
-        assert graphs[0].edge_props[i] is graphs[1].edge_props[i]
+        assert graphs[0].states[i] is graphs[1].states[i]
 
 
 def test_strip_projections():
@@ -254,8 +254,8 @@ def test_strip_projections():
     assert transition.interactions[1].l_projection == 0
 
     stripped_transition = _strip_projections(transition)  # type: ignore[arg-type]
-    assert stripped_transition.edge_props[3].name == resonance
-    assert stripped_transition.node_props[0].s_projection is None
-    assert stripped_transition.node_props[0].l_projection is None
-    assert stripped_transition.node_props[1].s_projection is None
-    assert stripped_transition.node_props[1].l_projection is None
+    assert stripped_transition.states[3].name == resonance
+    assert stripped_transition.interactions[0].s_projection is None
+    assert stripped_transition.interactions[0].l_projection is None
+    assert stripped_transition.interactions[1].s_projection is None
+    assert stripped_transition.interactions[1].l_projection is None

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -208,10 +208,10 @@ def test_collapse_graphs(
     particle_database: ParticleCollection,
 ):
     pdg = particle_database
-    particle_graphs = _get_particle_graphs(reaction.to_graphs())  # type: ignore[arg-type]
+    particle_graphs = _get_particle_graphs(reaction.transitions)  # type: ignore[arg-type]
     assert len(particle_graphs) == 2
 
-    collapsed_graphs = _collapse_graphs(reaction.to_graphs())  # type: ignore[arg-type]
+    collapsed_graphs = _collapse_graphs(reaction.transitions)  # type: ignore[arg-type]
     assert len(collapsed_graphs) == 1
     graph = next(iter(collapsed_graphs))
     edge_id = next(iter(graph.topology.intermediate_edge_ids))
@@ -226,7 +226,7 @@ def test_get_particle_graphs(
     reaction: ReactionInfo, particle_database: ParticleCollection
 ):
     pdg = particle_database
-    graphs = _get_particle_graphs(reaction.to_graphs())  # type: ignore[arg-type]
+    graphs = _get_particle_graphs(reaction.transitions)  # type: ignore[arg-type]
     assert len(graphs) == 2
     assert graphs[0].states[3] == pdg["f(0)(980)"]
     assert graphs[1].states[3] == pdg["f(0)(1500)"]

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -163,7 +163,11 @@ class TestWrite:
         output_file = output_dir + "two_body_decay_topology.gv"
         topology = Topology(
             nodes={0},
-            edges={0: Edge(0, None), 1: Edge(None, 0), 2: Edge(None, 0)},
+            edges={
+                -1: Edge(None, 0),
+                0: Edge(0, None),
+                1: Edge(0, None),
+            },
         )
         io.write(
             instance=topology,

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -9,7 +9,7 @@ from qrules.io._dot import (
     _get_particle_graphs,
     _strip_projections,
 )
-from qrules.particle import ParticleCollection
+from qrules.particle import Particle, ParticleCollection
 from qrules.topology import (
     Edge,
     Topology,
@@ -210,13 +210,15 @@ def test_collapse_graphs(
     pdg = particle_database
     particle_graphs = _get_particle_graphs(reaction.to_graphs())
     assert len(particle_graphs) == 2
+
     collapsed_graphs = _collapse_graphs(reaction.to_graphs())
     assert len(collapsed_graphs) == 1
     graph = next(iter(collapsed_graphs))
     edge_id = next(iter(graph.topology.intermediate_edge_ids))
     f_resonances = pdg.filter(lambda p: p.name in ["f(0)(980)", "f(0)(1500)"])
     intermediate_states = graph.states[edge_id]
-    assert isinstance(intermediate_states, ParticleCollection)
+    assert isinstance(intermediate_states, tuple)
+    assert all(map(lambda i: isinstance(i, Particle), intermediate_states))
     assert intermediate_states == f_resonances
 
 

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -215,7 +215,7 @@ def test_collapse_graphs(
     graph = next(iter(collapsed_graphs))
     edge_id = next(iter(graph.topology.intermediate_edge_ids))
     f_resonances = pdg.filter(lambda p: p.name in ["f(0)(980)", "f(0)(1500)"])
-    intermediate_states = graph.get_edge_props(edge_id)
+    intermediate_states = graph.edge_props[edge_id]
     assert isinstance(intermediate_states, ParticleCollection)
     assert intermediate_states == f_resonances
 
@@ -224,15 +224,13 @@ def test_get_particle_graphs(
     reaction: ReactionInfo, particle_database: ParticleCollection
 ):
     pdg = particle_database
-    particle_graphs = _get_particle_graphs(reaction.to_graphs())
-    assert len(particle_graphs) == 2
-    assert particle_graphs[0].get_edge_props(3) == pdg["f(0)(980)"]
-    assert particle_graphs[1].get_edge_props(3) == pdg["f(0)(1500)"]
-    assert len(particle_graphs[0].topology.edges) == 5
-    for edge_id in range(-1, 3):
-        assert particle_graphs[0].get_edge_props(edge_id) is particle_graphs[
-            1
-        ].get_edge_props(edge_id)
+    graphs = _get_particle_graphs(reaction.to_graphs())
+    assert len(graphs) == 2
+    assert graphs[0].edge_props[3] == pdg["f(0)(980)"]
+    assert graphs[1].edge_props[3] == pdg["f(0)(1500)"]
+    assert len(graphs[0].topology.edges) == 5
+    for i in range(-1, 3):
+        assert graphs[0].edge_props[i] is graphs[1].edge_props[i]
 
 
 def test_strip_projections():
@@ -256,8 +254,8 @@ def test_strip_projections():
     assert transition.interactions[1].l_projection == 0
 
     stripped_transition = _strip_projections(transition)  # type: ignore[arg-type]
-    assert stripped_transition.get_edge_props(3).name == resonance
-    assert stripped_transition.get_node_props(0).s_projection is None
-    assert stripped_transition.get_node_props(0).l_projection is None
-    assert stripped_transition.get_node_props(1).s_projection is None
-    assert stripped_transition.get_node_props(1).l_projection is None
+    assert stripped_transition.edge_props[3].name == resonance
+    assert stripped_transition.node_props[0].s_projection is None
+    assert stripped_transition.node_props[0].l_projection is None
+    assert stripped_transition.node_props[1].s_projection is None
+    assert stripped_transition.node_props[1].l_projection is None

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -5,7 +5,7 @@ import pytest
 from qrules import io
 from qrules.particle import Particle, ParticleCollection
 from qrules.topology import (
-    StateTransitionGraph,
+    MutableTransition,
     Topology,
     create_isobar_topologies,
     create_n_body_topology,
@@ -44,10 +44,10 @@ def test_asdict_fromdict(particle_selection: ParticleCollection):
 
 
 def test_asdict_fromdict_reaction(reaction: ReactionInfo):
-    # StateTransitionGraph
+    # MutableTransition
     for graph in reaction.to_graphs():
         fromdict = through_dict(graph)
-        assert isinstance(fromdict, StateTransitionGraph)
+        assert isinstance(fromdict, MutableTransition)
         assert graph == fromdict
     # ReactionInfo
     fromdict = through_dict(reaction)

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -10,7 +10,7 @@ from qrules.topology import (
     create_isobar_topologies,
     create_n_body_topology,
 )
-from qrules.transition import ReactionInfo, State
+from qrules.transition import ReactionInfo
 
 
 def through_dict(instance):
@@ -44,11 +44,11 @@ def test_asdict_fromdict(particle_selection: ParticleCollection):
 
 
 def test_asdict_fromdict_reaction(reaction: ReactionInfo):
-    # MutableTransition
-    for graph in reaction.to_graphs():
+    # FrozenTransition
+    for graph in reaction.transitions:
         fromdict = through_dict(graph)
         assert isinstance(fromdict, FrozenTransition)
-        assert graph.freeze().convert(lambda s: State(*s)) == fromdict
+        assert graph == fromdict
     # ReactionInfo
     fromdict = through_dict(reaction)
     assert isinstance(fromdict, ReactionInfo)

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -5,11 +5,12 @@ import pytest
 from qrules import io
 from qrules.particle import Particle, ParticleCollection
 from qrules.topology import (
+    FrozenTransition,
     Topology,
     create_isobar_topologies,
     create_n_body_topology,
 )
-from qrules.transition import ReactionInfo, StateTransition
+from qrules.transition import ReactionInfo, State
 
 
 def through_dict(instance):
@@ -46,8 +47,8 @@ def test_asdict_fromdict_reaction(reaction: ReactionInfo):
     # MutableTransition
     for graph in reaction.to_graphs():
         fromdict = through_dict(graph)
-        assert isinstance(fromdict, StateTransition)
-        assert graph == fromdict.to_graph()
+        assert isinstance(fromdict, FrozenTransition)
+        assert graph.freeze().convert(lambda s: State(*s)) == fromdict
     # ReactionInfo
     fromdict = through_dict(reaction)
     assert isinstance(fromdict, ReactionInfo)

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -5,12 +5,11 @@ import pytest
 from qrules import io
 from qrules.particle import Particle, ParticleCollection
 from qrules.topology import (
-    MutableTransition,
     Topology,
     create_isobar_topologies,
     create_n_body_topology,
 )
-from qrules.transition import ReactionInfo
+from qrules.transition import ReactionInfo, StateTransition
 
 
 def through_dict(instance):
@@ -47,8 +46,8 @@ def test_asdict_fromdict_reaction(reaction: ReactionInfo):
     # MutableTransition
     for graph in reaction.to_graphs():
         fromdict = through_dict(graph)
-        assert isinstance(fromdict, MutableTransition)
-        assert graph == fromdict
+        assert isinstance(fromdict, StateTransition)
+        assert graph == fromdict.to_graph()
     # ReactionInfo
     fromdict = through_dict(reaction)
     assert isinstance(fromdict, ReactionInfo)

--- a/tests/unit/test_combinatorics.py
+++ b/tests/unit/test_combinatorics.py
@@ -98,14 +98,14 @@ class TestKinematicRepresentation:
     def test_from_topology(self, three_body_decay: Topology):
         pi0 = ("pi0", [0])
         gamma = ("gamma", [-1, 1])
-        edge_props = {
+        states = {
             -1: ("J/psi", [-1, +1]),
             0: pi0,
             1: pi0,
             2: gamma,
         }
         kinematic_representation1 = _get_kinematic_representation(
-            three_body_decay, edge_props
+            three_body_decay, states
         )
         assert kinematic_representation1.initial_state == [
             ["J/psi"],

--- a/tests/unit/test_system_control.py
+++ b/tests/unit/test_system_control.py
@@ -1,6 +1,6 @@
 # pylint: disable=protected-access
 from copy import deepcopy
-from typing import List
+from typing import Dict, List
 
 import attrs
 import pytest
@@ -208,38 +208,36 @@ def test_create_edge_properties(
 def make_ls_test_graph(
     angular_momentum_magnitude, coupled_spin_magnitude, particle
 ):
-    graph = StateTransitionGraph[ParticleWithSpin](
-        topology=Topology(
-            nodes={0},
-            edges={0: Edge(None, 0)},
-        ),
-        node_props={
-            0: InteractionProperties(
-                s_magnitude=coupled_spin_magnitude,
-                l_magnitude=angular_momentum_magnitude,
-            )
-        },
-        edge_props={0: (particle, 0)},
+    topology = Topology(
+        nodes={0},
+        edges={0: Edge(None, 0)},
     )
+    node_props = {
+        0: InteractionProperties(
+            s_magnitude=coupled_spin_magnitude,
+            l_magnitude=angular_momentum_magnitude,
+        )
+    }
+    edge_props: Dict[int, ParticleWithSpin] = {0: (particle, 0)}
+    graph = StateTransitionGraph(topology, node_props, edge_props)
     return graph
 
 
 def make_ls_test_graph_scrambled(
     angular_momentum_magnitude, coupled_spin_magnitude, particle
 ):
-    graph = StateTransitionGraph[ParticleWithSpin](
-        topology=Topology(
-            nodes={0},
-            edges={0: Edge(None, 0)},
-        ),
-        node_props={
-            0: InteractionProperties(
-                l_magnitude=angular_momentum_magnitude,
-                s_magnitude=coupled_spin_magnitude,
-            )
-        },
-        edge_props={0: (particle, 0)},
+    topology = Topology(
+        nodes={0},
+        edges={0: Edge(None, 0)},
     )
+    node_props = {
+        0: InteractionProperties(
+            l_magnitude=angular_momentum_magnitude,
+            s_magnitude=coupled_spin_magnitude,
+        )
+    }
+    edge_props: Dict[int, ParticleWithSpin] = {0: (particle, 0)}
+    graph = StateTransitionGraph(topology, node_props, edge_props)
     return graph
 
 
@@ -343,8 +341,8 @@ class TestSolutionFilter:  # pylint: disable=no-self-use
 
 def _create_graph(
     problem_set: ProblemSet,
-) -> StateTransitionGraph[ParticleWithSpin]:
-    return StateTransitionGraph[ParticleWithSpin](
+) -> StateTransitionGraph[ParticleWithSpin, InteractionProperties]:
+    return StateTransitionGraph(
         topology=problem_set.topology,
         node_props=problem_set.initial_facts.node_props,
         edge_props=problem_set.initial_facts.edge_props,
@@ -371,7 +369,9 @@ def test_edge_swap(particle_database, initial_state, final_state):
     stm.set_allowed_interaction_types([InteractionType.STRONG])
 
     problem_sets = stm.create_problem_sets()
-    init_graphs: List[StateTransitionGraph[ParticleWithSpin]] = []
+    init_graphs: List[
+        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ] = []
     for _, problem_set_list in problem_sets.items():
         init_graphs.extend([_create_graph(x) for x in problem_set_list])
 
@@ -417,7 +417,9 @@ def test_match_external_edges(particle_database, initial_state, final_state):
     stm.set_allowed_interaction_types([InteractionType.STRONG])
 
     problem_sets = stm.create_problem_sets()
-    init_graphs: List[StateTransitionGraph[ParticleWithSpin]] = []
+    init_graphs: List[
+        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ] = []
     for _, problem_set_list in problem_sets.items():
         init_graphs.extend([_create_graph(x) for x in problem_set_list])
 
@@ -506,7 +508,9 @@ def test_external_edge_identical_particle_combinatorics(
 
     match_external_edges(init_graphs)
 
-    comb_graphs: List[StateTransitionGraph[ParticleWithSpin]] = []
+    comb_graphs: List[
+        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+    ] = []
     for group in init_graphs:
         comb_graphs.extend(
             perform_external_edge_identical_particle_combinatorics(group)

--- a/tests/unit/test_system_control.py
+++ b/tests/unit/test_system_control.py
@@ -2,6 +2,7 @@
 from copy import deepcopy
 from typing import List
 
+import attrs
 import pytest
 
 from qrules import InteractionType, ProblemSet, StateTransitionManager
@@ -324,13 +325,14 @@ class TestSolutionFilter:  # pylint: disable=no-self-use
 
         for value in input_values:
             tempgraph = make_ls_test_graph(value[1][0], value[1][1], pi0)
-            tempgraph = tempgraph.evolve(
+            tempgraph = attrs.evolve(
+                tempgraph,
                 edge_props={
                     0: (
                         Particle(name=value[0], pid=0, mass=1.0, spin=1.0),
                         0.0,
                     )
-                }
+                },
             )
             graphs.append(tempgraph)
 

--- a/tests/unit/test_system_control.py
+++ b/tests/unit/test_system_control.py
@@ -212,14 +212,14 @@ def make_ls_test_graph(
         nodes={0},
         edges={0: Edge(None, 0)},
     )
-    node_props = {
+    interactions = {
         0: InteractionProperties(
             s_magnitude=coupled_spin_magnitude,
             l_magnitude=angular_momentum_magnitude,
         )
     }
-    edge_props: Dict[int, ParticleWithSpin] = {0: (particle, 0)}
-    graph = MutableTransition(topology, node_props, edge_props)
+    states: Dict[int, ParticleWithSpin] = {0: (particle, 0)}
+    graph = MutableTransition(topology, states, interactions)
     return graph
 
 
@@ -230,14 +230,14 @@ def make_ls_test_graph_scrambled(
         nodes={0},
         edges={0: Edge(None, 0)},
     )
-    node_props = {
+    interactions = {
         0: InteractionProperties(
             l_magnitude=angular_momentum_magnitude,
             s_magnitude=coupled_spin_magnitude,
         )
     }
-    edge_props: Dict[int, ParticleWithSpin] = {0: (particle, 0)}
-    graph = MutableTransition(topology, node_props, edge_props)
+    states: Dict[int, ParticleWithSpin] = {0: (particle, 0)}
+    graph = MutableTransition(topology, states, interactions)
     return graph
 
 
@@ -325,7 +325,7 @@ class TestSolutionFilter:  # pylint: disable=no-self-use
             tempgraph = make_ls_test_graph(value[1][0], value[1][1], pi0)
             tempgraph = attrs.evolve(
                 tempgraph,
-                edge_props={
+                states={
                     0: (
                         Particle(name=value[0], pid=0, mass=1.0, spin=1.0),
                         0.0,
@@ -344,8 +344,8 @@ def _create_graph(
 ) -> MutableTransition[ParticleWithSpin, InteractionProperties]:
     return MutableTransition(
         topology=problem_set.topology,
-        node_props=problem_set.initial_facts.node_props,
-        edge_props=problem_set.initial_facts.edge_props,
+        interactions=problem_set.initial_facts.interactions,
+        states=problem_set.initial_facts.states,
     )
 
 
@@ -382,15 +382,15 @@ def test_edge_swap(particle_database, initial_state, final_state):
         edge_keys = list(ref_mapping.keys())
         edge1 = edge_keys[0]
         edge1_val = graph.topology.edges[edge1]
-        edge1_props = deepcopy(graph.edge_props[edge1])
+        edge1_props = deepcopy(graph.states[edge1])
         edge2 = edge_keys[1]
         edge2_val = graph.topology.edges[edge2]
-        edge2_props = deepcopy(graph.edge_props[edge2])
+        edge2_props = deepcopy(graph.states[edge2])
         graph.swap_edges(edge1, edge2)
         assert graph.topology.edges[edge1] == edge2_val
         assert graph.topology.edges[edge2] == edge1_val
-        assert graph.edge_props[edge1] == edge2_props
-        assert graph.edge_props[edge2] == edge1_props
+        assert graph.states[edge1] == edge2_props
+        assert graph.states[edge2] == edge1_props
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_system_control.py
+++ b/tests/unit/test_system_control.py
@@ -24,7 +24,7 @@ from qrules.quantum_numbers import (
     InteractionProperties,
     NodeQuantumNumbers,
 )
-from qrules.topology import Edge, StateTransitionGraph, Topology
+from qrules.topology import Edge, MutableTransition, Topology
 
 
 @pytest.mark.parametrize(
@@ -219,7 +219,7 @@ def make_ls_test_graph(
         )
     }
     edge_props: Dict[int, ParticleWithSpin] = {0: (particle, 0)}
-    graph = StateTransitionGraph(topology, node_props, edge_props)
+    graph = MutableTransition(topology, node_props, edge_props)
     return graph
 
 
@@ -237,7 +237,7 @@ def make_ls_test_graph_scrambled(
         )
     }
     edge_props: Dict[int, ParticleWithSpin] = {0: (particle, 0)}
-    graph = StateTransitionGraph(topology, node_props, edge_props)
+    graph = MutableTransition(topology, node_props, edge_props)
     return graph
 
 
@@ -341,8 +341,8 @@ class TestSolutionFilter:  # pylint: disable=no-self-use
 
 def _create_graph(
     problem_set: ProblemSet,
-) -> StateTransitionGraph[ParticleWithSpin, InteractionProperties]:
-    return StateTransitionGraph(
+) -> MutableTransition[ParticleWithSpin, InteractionProperties]:
+    return MutableTransition(
         topology=problem_set.topology,
         node_props=problem_set.initial_facts.node_props,
         edge_props=problem_set.initial_facts.edge_props,
@@ -370,7 +370,7 @@ def test_edge_swap(particle_database, initial_state, final_state):
 
     problem_sets = stm.create_problem_sets()
     init_graphs: List[
-        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+        MutableTransition[ParticleWithSpin, InteractionProperties]
     ] = []
     for _, problem_set_list in problem_sets.items():
         init_graphs.extend([_create_graph(x) for x in problem_set_list])
@@ -418,7 +418,7 @@ def test_match_external_edges(particle_database, initial_state, final_state):
 
     problem_sets = stm.create_problem_sets()
     init_graphs: List[
-        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+        MutableTransition[ParticleWithSpin, InteractionProperties]
     ] = []
     for _, problem_set_list in problem_sets.items():
         init_graphs.extend([_create_graph(x) for x in problem_set_list])
@@ -509,7 +509,7 @@ def test_external_edge_identical_particle_combinatorics(
     match_external_edges(init_graphs)
 
     comb_graphs: List[
-        StateTransitionGraph[ParticleWithSpin, InteractionProperties]
+        MutableTransition[ParticleWithSpin, InteractionProperties]
     ] = []
     for group in init_graphs:
         comb_graphs.extend(

--- a/tests/unit/test_system_control.py
+++ b/tests/unit/test_system_control.py
@@ -341,7 +341,7 @@ class TestSolutionFilter:  # pylint: disable=no-self-use
 
 def _create_graph(
     problem_set: ProblemSet,
-) -> MutableTransition[ParticleWithSpin, InteractionProperties]:
+) -> "MutableTransition[ParticleWithSpin, InteractionProperties]":
     return MutableTransition(
         topology=problem_set.topology,
         interactions=problem_set.initial_facts.interactions,

--- a/tests/unit/test_system_control.py
+++ b/tests/unit/test_system_control.py
@@ -380,15 +380,15 @@ def test_edge_swap(particle_database, initial_state, final_state):
         edge_keys = list(ref_mapping.keys())
         edge1 = edge_keys[0]
         edge1_val = graph.topology.edges[edge1]
-        edge1_props = deepcopy(graph.get_edge_props(edge1))
+        edge1_props = deepcopy(graph.edge_props[edge1])
         edge2 = edge_keys[1]
         edge2_val = graph.topology.edges[edge2]
-        edge2_props = deepcopy(graph.get_edge_props(edge2))
+        edge2_props = deepcopy(graph.edge_props[edge2])
         graph.swap_edges(edge1, edge2)
         assert graph.topology.edges[edge1] == edge2_val
         assert graph.topology.edges[edge2] == edge1_val
-        assert graph.get_edge_props(edge1) == edge2_props
-        assert graph.get_edge_props(edge2) == edge1_props
+        assert graph.edge_props[edge1] == edge2_props
+        assert graph.edge_props[edge2] == edge1_props
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_system_control.py
+++ b/tests/unit/test_system_control.py
@@ -210,7 +210,7 @@ def make_ls_test_graph(
 ):
     topology = Topology(
         nodes={0},
-        edges={0: Edge(None, 0)},
+        edges={-1: Edge(None, 0)},
     )
     interactions = {
         0: InteractionProperties(
@@ -218,7 +218,7 @@ def make_ls_test_graph(
             l_magnitude=angular_momentum_magnitude,
         )
     }
-    states: Dict[int, ParticleWithSpin] = {0: (particle, 0)}
+    states: Dict[int, ParticleWithSpin] = {-1: (particle, 0)}
     graph = MutableTransition(topology, states, interactions)
     return graph
 
@@ -228,7 +228,7 @@ def make_ls_test_graph_scrambled(
 ):
     topology = Topology(
         nodes={0},
-        edges={0: Edge(None, 0)},
+        edges={-1: Edge(None, 0)},
     )
     interactions = {
         0: InteractionProperties(
@@ -236,7 +236,7 @@ def make_ls_test_graph_scrambled(
             s_magnitude=coupled_spin_magnitude,
         )
     }
-    states: Dict[int, ParticleWithSpin] = {0: (particle, 0)}
+    states: Dict[int, ParticleWithSpin] = {-1: (particle, 0)}
     graph = MutableTransition(topology, states, interactions)
     return graph
 
@@ -326,7 +326,7 @@ class TestSolutionFilter:  # pylint: disable=no-self-use
             tempgraph = attrs.evolve(
                 tempgraph,
                 states={
-                    0: (
+                    -1: (
                         Particle(name=value[0], pid=0, mass=1.0, spin=1.0),
                         0.0,
                     )

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -177,7 +177,7 @@ class TestTopology:
         ],
     )
     def test_constructor(self, nodes, edges):
-        topology = Topology(nodes=nodes, edges=edges)
+        topology = Topology(nodes, edges)
         if nodes is None:
             nodes = set()
         if edges is None:
@@ -202,7 +202,7 @@ class TestTopology:
                 r"(not connected to any other node|has non-existing node IDs)"
             ),
         ):
-            assert Topology(nodes=nodes, edges=edges)
+            assert Topology(nodes, edges)
 
     @pytest.mark.parametrize("repr_method", [repr, pretty])
     def test_repr_and_eq(self, repr_method, two_to_three_decay: Topology):

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -10,9 +10,9 @@ from qrules.topology import (  # noqa: F401
     Edge,
     FrozenDict,
     InteractionNode,
+    MutableTopology,
     SimpleStateTransitionTopologyBuilder,
     Topology,
-    _MutableTopology,
     create_isobar_topologies,
     create_n_body_topology,
     get_originating_node_list,
@@ -100,7 +100,7 @@ class TestInteractionNode:
 
 class TestMutableTopology:
     def test_add_and_attach(self, two_to_three_decay: Topology):
-        topology = _MutableTopology(
+        topology = MutableTopology(
             edges=two_to_three_decay.edges,
             nodes=two_to_three_decay.nodes,  # type: ignore[arg-type]
         )
@@ -116,7 +116,7 @@ class TestMutableTopology:
         assert isinstance(topology.freeze(), Topology)
 
     def test_add_exceptions(self, two_to_three_decay: Topology):
-        topology = _MutableTopology(
+        topology = MutableTopology(
             edges=two_to_three_decay.edges,
             nodes=two_to_three_decay.nodes,  # type: ignore[arg-type]
         )

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -102,7 +102,7 @@ class TestMutableTopology:
     def test_add_and_attach(self, two_to_three_decay: Topology):
         topology = MutableTopology(
             edges=two_to_three_decay.edges,
-            nodes=two_to_three_decay.nodes,  # type: ignore[arg-type]
+            nodes=two_to_three_decay.nodes,
         )
         topology.add_node(3)
         topology.add_edges([7, 8])
@@ -118,7 +118,7 @@ class TestMutableTopology:
     def test_add_exceptions(self, two_to_three_decay: Topology):
         topology = MutableTopology(
             edges=two_to_three_decay.edges,
-            nodes=two_to_three_decay.nodes,  # type: ignore[arg-type]
+            nodes=two_to_three_decay.nodes,
         )
         with pytest.raises(ValueError, match=r"Node nr. 0 already exists"):
             topology.add_node(0)

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -271,21 +271,10 @@ class TestTopology:
         topology = topology.swap_edges(0, 1)
         assert topology != original_topology
 
-    @pytest.mark.parametrize(
-        ("n_final_states", "expected_order"),
-        [
-            (2, [0]),
-            (3, [0]),
-            (4, [1, 0]),
-            (5, [3, 2, 4, 1, 0]),
-            (6, [13, 9, 7, 10, 6, 5, 14, 11, 8, 15, 3, 2, 12, 4, 1, 0]),
-        ],
-    )
-    def test_unique_ordering(self, n_final_states, expected_order):
+    @pytest.mark.parametrize("n_final_states", [2, 3, 4, 5, 6])
+    def test_unique_ordering(self, n_final_states):
         topologies = create_isobar_topologies(n_final_states)
-        sorted_topologies = sorted(topologies)
-        order = [sorted_topologies.index(t) for t in topologies]
-        assert order == expected_order
+        assert sorted(topologies) == list(topologies)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_transition.py
+++ b/tests/unit/test_transition.py
@@ -17,7 +17,7 @@ from qrules.quantum_numbers import InteractionProperties  # noqa: F401
 from qrules.topology import (  # noqa: F401
     Edge,
     FrozenDict,
-    StateTransitionGraph,
+    MutableTransition,
     Topology,
 )
 from qrules.transition import State  # noqa: F401

--- a/tests/unit/test_transition.py
+++ b/tests/unit/test_transition.py
@@ -1,5 +1,7 @@
 # pyright: reportUnusedImport=false
 # pylint: disable=eval-used, no-self-use
+from copy import deepcopy
+
 import pytest
 from IPython.lib.pretty import pretty
 
@@ -40,15 +42,8 @@ class TestReactionInfo:
         from_repr = eval(repr_method(instance))
         assert from_repr == instance
 
-    def test_from_to_graphs(self, reaction: ReactionInfo):
-        graphs = reaction.to_graphs()
-        from_graphs = ReactionInfo.from_graphs(graphs, reaction.formalism)
-        assert from_graphs == reaction
-
     def test_hash(self, reaction: ReactionInfo):
-        graphs = reaction.to_graphs()
-        from_graphs = ReactionInfo.from_graphs(graphs, reaction.formalism)
-        assert hash(from_graphs) == hash(reaction)
+        assert hash(deepcopy(reaction)) == hash(reaction)
 
 
 class TestState:

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ commands =
         --watch src \
         --re-ignore .*/.ipynb_checkpoints/.* \
         --re-ignore .*/__pycache__/.* \
+        --re-ignore .*\.tmp \
         --re-ignore docs/.*\.csv \
         --re-ignore docs/.*\.gv \
         --re-ignore docs/.*\.inv \

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ commands =
         --re-ignore docs/.*\.yaml \
         --re-ignore docs/.*\.yml \
         --re-ignore docs/_build/.* \
+        --re-ignore docs/_images/.* \
         --re-ignore docs/_static/logo\..* \
         --re-ignore docs/api/.* \
         --open-browser \

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ commands =
         --re-ignore docs/.*\.yaml \
         --re-ignore docs/.*\.yml \
         --re-ignore docs/_build/.* \
+        --re-ignore docs/_static/logo\..* \
         --re-ignore docs/api/.* \
         --open-browser \
         docs/ docs/_build/html


### PR DESCRIPTION
All classes that map properties onto a [`Topology`](https://qrules--156.org.readthedocs.build/en/156/api/qrules.topology.html#qrules.topology.Topology) are now a [`Transition`](https://qrules--156.org.readthedocs.build/en/156/api/qrules.topology.html#qrules.topology.Transition). A distinction is made between [`MutableTransition`](https://qrules--156.org.readthedocs.build/en/156/api/qrules.topology.html#qrules.topology.MutableTransition) (for instance, the original [`StateTransitionGraph`](https://qrules.readthedocs.io/en/0.9.7/api/qrules.transition.html#qrules.transition.StateTransitionGraph)) and a [`FrozenTransition`](https://qrules--156.org.readthedocs.build/en/156/api/qrules.topology.html#qrules.topology.FrozenTransition) (hashable and ordered―the original [`StateTransition`](https://qrules.readthedocs.io/en/0.9.7/api/qrules.transition.html#qrules.transition.StateTransition) class).

New design can best be read about in the renewed API of the [`qrules.topology`](https://qrules--156.org.readthedocs.build/en/156/api/qrules.topology.html) module.