### PR TITLE
fix: define execution_info outside conditionals

### DIFF
--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -606,11 +606,11 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             self.filter_ignore_qns,
         )
 
+        execution_info = final_result.execution_info
         if (
             final_result.execution_info.violated_edge_rules
             or final_result.execution_info.violated_node_rules
         ):
-            execution_info = final_result.execution_info
             violated_rules: Set[str] = set()
             for rules in execution_info.violated_edge_rules.values():
                 violated_rules |= rules


### PR DESCRIPTION
Causes a small bug in case no solutions are found. E.g.:

```python
import qrules

reaction = qrules.generate_transitions(
    initial_state=("psi(4160)", [-1, +1]),
    final_state=["D-", "D0", "pi+"],
    allowed_intermediate_particles=[],  # <-- wrong, but should not crash
)
```

See also #33