### PR TITLE
ENH: warn instead of raise violated rules

### DIFF
--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -584,7 +584,7 @@ class StateTransitionManager:
             warnings.warn(msg, category=RuntimeWarning, stacklevel=1)
         if not final_solutions:
             msg = "No solutions were found"
-            raise ValueError(msg)
+            raise RuntimeError(msg, execution_info)
 
         match_external_edges(final_solutions)
         final_solutions = [


### PR DESCRIPTION
So far, when there are violated rules and/or non-executed rules, `find_solutions()` raises these as a `RuntimeWarning`. This is an incorrect use of this exception class that also prevents the user from inspecting the execution info. The [`RuntimeWarning`](https://docs.python.org/3/library/exceptions.html#RuntimeWarning) is therefore now passed through [`warnings.warn()`](https://docs.python.org/3/library/warnings.html#warnings.warn). The warnings can then be switch off with:

```python
import warnings
warnings.simplefilter("ignore", category=RuntimeWarning)
```

Still, if there are violated rules, there are no solutions, so an exception is still raised (now as a `RuntimeError` instead of a `ValueError`. [`ExecutionInfo`](https://qrules.readthedocs.io/en/0.10.x/api/qrules.transition.html#qrules.transition.ExecutionInfo) is now passed on to this exception, so that it can be further inspected:

```python
import qrules
try:
    reaction = qrules.generate_transitions(
        initial_state=["pi0"],
        final_state=["gamma", "gamma", "gamma"],
        allowed_interaction_types=["em"],
    )
except RuntimeError as e:
    msg, execution_info = e.args
execution_info.not_executed_node_rules
```

_See also #174_