### PR TITLE
FIX: show only selected rules in DOT rendering

### DIFF
--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -387,9 +387,9 @@ def _(settings: Union[EdgeSettings, NodeSettings]) -> str:
     return output
 
 
-def __get_priority(rule: Any, rule_priorities: Dict[Any, int]) -> Optional[int]:
+def __get_priority(rule: Any, rule_priorities: Dict[Any, int]) -> Union[int, str]:
     rule_type = __get_type(rule)
-    return rule_priorities[rule_type]
+    return rule_priorities.get(rule_type, "NA")
 
 
 def __render_rule(rule: Rule) -> str:
@@ -402,13 +402,12 @@ def __get_type(rule: Rule) -> Type[Rule]:
     return type(rule)
 
 
-def __extract_priority(description: str) -> int:
-    matches = re.match(r".* \- ([0-9]+)$", description)
+def __extract_priority(description: str) -> str:
+    matches = re.match(r".* \- ([0-9]+|NA)$", description)
     if matches is None:
         msg = f"{description} does not contain a priority number"
         raise ValueError(msg)
-    priority = matches[1]
-    return int(priority)
+    return matches[1]
 
 
 @as_string.register(Particle)


### PR DESCRIPTION
Previously, a DOT rendering of a [`ProblemSet`](https://qrules.readthedocs.io/en/0.10.x/api/qrules.transition.html#qrules.transition.ProblemSet) rendered only [`rule_priorities`](https://qrules.readthedocs.io/en/0.10.x/api/qrules.solving.html#qrules.solving.NodeSettings.rule_priorities). This is, however, just an exhaustive list of priorities for each rule that are in most cases the [default rule prioties](https://github.com/ComPWA/qrules/blob/c6315c8bcbabf9a07d5469f50f122997cc7eb7b9/src/qrules/settings.py#L134), not a list of _selected_ rules for each node or edge. This fix renders the selected [`conservation_rules`](https://qrules.readthedocs.io/en/0.10.x/api/qrules.solving.html#qrules.solving.NodeSettings.conservation_rules) instead:

<details>
<summary>Code snippet</summary>

```python
import graphviz

import qrules
from qrules.settings import InteractionType
from qrules.transition import StateTransitionManager

stm = StateTransitionManager(
    initial_state=["Lambda(c)+"],
    final_state=["p", "K-", "pi+"],
    mass_conservation_factor=0.6,
)
stm.set_allowed_interaction_types([InteractionType.WEAK], node_id=0)
stm.set_allowed_interaction_types([InteractionType.STRONG], node_id=1)
problem_sets = stm.create_problem_sets()
problem_set, *_ = problem_sets.values()
src = qrules.io.asdot(problem_set[0], render_node=True)
graphviz.Source(src)
```

</details>

### Before
![before](https://github.com/ComPWA/qrules/assets/29308176/3bac23f0-659f-4ece-90a4-cde77e9ed3bb)

### After
![after](https://github.com/ComPWA/qrules/assets/29308176/a28558b6-0f74-41c3-97b4-c54bab48d129)
