### PR TITLE
DX: remove `figure_formats = ["svg"]` statement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.1.4
+    rev: 0.1.5
     hooks:
       - id: check-dev-files
         args:

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -43,7 +43,6 @@
    },
    "outputs": [],
    "source": [
-    "%config InlineBackend.figure_formats = ['svg']\n",
     "import os\n",
     "\n",
     "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)"

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -43,7 +43,6 @@
    },
    "outputs": [],
    "source": [
-    "%config InlineBackend.figure_formats = ['svg']\n",
     "import os\n",
     "\n",
     "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)"

--- a/docs/usage/custom-topology.ipynb
+++ b/docs/usage/custom-topology.ipynb
@@ -43,7 +43,6 @@
    },
    "outputs": [],
    "source": [
-    "%config InlineBackend.figure_formats = ['svg']\n",
     "import os\n",
     "\n",
     "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)"

--- a/docs/usage/ls-coupling.ipynb
+++ b/docs/usage/ls-coupling.ipynb
@@ -43,7 +43,6 @@
    },
    "outputs": [],
    "source": [
-    "%config InlineBackend.figure_formats = ['svg']\n",
     "import os\n",
     "\n",
     "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)"

--- a/docs/usage/particle.ipynb
+++ b/docs/usage/particle.ipynb
@@ -43,7 +43,6 @@
    },
    "outputs": [],
    "source": [
-    "%config InlineBackend.figure_formats = ['svg']\n",
     "import os\n",
     "\n",
     "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)"

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -43,7 +43,6 @@
    },
    "outputs": [],
    "source": [
-    "%config InlineBackend.figure_formats = ['svg']\n",
     "import os\n",
     "\n",
     "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)"

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -43,7 +43,6 @@
    },
    "outputs": [],
    "source": [
-    "%config InlineBackend.figure_formats = ['svg']\n",
     "import os\n",
     "\n",
     "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)"


### PR DESCRIPTION
Closes https://github.com/ComPWA/repo-maintenance/issues/221

```[tasklist]
### Tasks
- [x] As can be seen in the [preview](https://qrules--237.org.readthedocs.build/en/237), there are no matplotlib figures that require setting `%config InlineBackend.figure_formats = ['svg']`.
```