### PR TITLE
MAINT: update pip constraints and pre-commit

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -141,7 +141,7 @@ rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.11.txt
+++ b/.constraints/py3.11.txt
@@ -140,7 +140,7 @@ rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.12.txt
+++ b/.constraints/py3.12.txt
@@ -140,7 +140,7 @@ rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -146,7 +146,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rope==1.9.0
 ruff==0.1.15
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -146,7 +146,7 @@ rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -141,7 +141,7 @@ rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
             metadata.vscode
 
   - repo: https://github.com/ComPWA/policy
-    rev: 0.3.4
+    rev: 0.3.5
     hooks:
       - id: check-dev-files
         args:
@@ -67,7 +67,7 @@ repos:
         types_or: [python, pyi, jupyter]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-ast
       - id: check-case-conflict


### PR DESCRIPTION
This PR updates the [`pip` constraint files](https://github.com/ComPWA/update-pip-constraints?tab=readme-ov-file#update-pip-constraint-files) under the `.constraints/` directory and pre-commit hooks in [`.pre-commit-config.yaml`](https://pre-commit.com). It was created automatically by a scheduled workflow.