### PR TITLE
FIX: print top number in Gell-Mann-Nishijima error

### DIFF
--- a/src/qrules/particle.py
+++ b/src/qrules/particle.py
@@ -180,7 +180,7 @@ class Particle:
                 f" Q[{self.charge}] !="
                 f" Iz[{self.isospin.projection if self.isospin else 0}] + 1/2"
                 f" (B[{self.baryon_number}] +  S[{self.strangeness}] + "
-                f" C[{self.charmness}] + B'[{self.bottomness}] + T[{self.strangeness}])"
+                f" C[{self.charmness}] + B'[{self.bottomness}] + T[{self.topness}])"
             )
             raise ValueError(msg)
 


### PR DESCRIPTION
Error message when constructing $\Lambda(2000)$ was this:

```
Q[0] != Iz[0.0] + 1/2 (B[1] +  S[1] +  C[0] + B'[0] + T[1])
```

because strangeness is printed for `T`.