### PR TITLE
ENH: make `Parity.value` of type `Literal[-1, 1]`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,7 @@ api_target_substitutions: dict[str, str | tuple[str, str]] = {
     "qrules.topology.NodeType": "typing.TypeVar",
     "SpinFormalism": ("obj", "qrules.transition.SpinFormalism"),
     "StateDefinition": ("obj", "qrules.combinatorics.StateDefinition"),
+    "typing.Literal[-1, 1]": "typing.Literal",
 }
 api_target_types: dict[str, str | tuple[str, str]] = {
     "qrules.combinatorics.InitialFacts": "obj",


### PR DESCRIPTION
Small improvements to the `Parity` class: it's `parity` attribute is now of type `Literal[-1, 1]` and it can be constructed from anything that `SupportsInt`.