### PR TITLE
DOC: switch back to Sphinx `html` builder

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sphinx:
-  builder: dirhtml
+  builder: html
   configuration: docs/conf.py
   fail_on_warning: true
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
   sphinx-build \
     --keep-going \
     -TW \
-    -b dirhtml \
+    -b html \
     docs/ docs/_build/html
 description =
   Build documentation and API through Sphinx
@@ -64,7 +64,7 @@ commands =
     --re-ignore docs/api/.* \
     --watch docs \
     --watch src \
-    -b dirhtml \
+    -b html \
     docs/ docs/_build/html
 description =
   Set up a server to directly preview changes to the HTML pages
@@ -79,7 +79,7 @@ commands =
   sphinx-build \
     --keep-going \
     -TW \
-    -b dirhtml \
+    -b html \
     docs/ docs/_build/html
 description =
   Build documentation through Sphinx WITH output of Jupyter notebooks
@@ -111,7 +111,7 @@ commands =
     --re-ignore docs/api/.* \
     --watch docs \
     --watch src \
-    -b dirhtml \
+    -b html \
     docs/ docs/_build/html
 description =
   Set up a server to directly preview changes to the HTML pages
@@ -127,7 +127,7 @@ allowlist_externals =
 commands =
   sphinx-build \
     --keep-going \
-    -b dirhtml \
+    -b html \
     -nW \
     docs/ docs/_build/html
 description =


### PR DESCRIPTION
Partially reverts #245 by switching back from the Sphinx [`dirhtml`](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.dirhtml.DirectoryHTMLBuilder) to [`html`](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.html.StandaloneHTMLBuilder) (see https://github.com/ComPWA/policy/issues/158). This again results in URLs like `https://qrules.rtfd.io/usage.html`, but avoid other DX problems, like https://github.com/ComPWA/policy/issues/335 and bad page navigation when opening the files locally.

> [!TIP]
> It is best to link to pages with e.g. `https://qrules.rtfd.io/usage/` (note the final `/`) instead of `https://qrules.rtfd.io/usage` or `https://qrules.rtfd.io/usage.html`. This will correctly redirect to the usage page, whether it uses the `dirhtml` builder or `html` builder.