### PR TITLE
MAINT: remove cell metadata `editable` and `slideshow`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,10 @@ repos:
           - |
             cell.attachments
             cell.metadata.code_folding
+            cell.metadata.editable
             cell.metadata.id
             cell.metadata.pycharm
+            cell.metadata.slideshow
             cell.metadata.user_expressions
             metadata.celltoolbar
             metadata.colab.name

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
             metadata.vscode
 
   - repo: https://github.com/ComPWA/policy
-    rev: 0.3.9
+    rev: 0.3.10
     hooks:
       - id: check-dev-files
         args:
@@ -53,6 +53,7 @@ repos:
           - --repo-title=QRules
       - id: colab-toc-visible
       - id: fix-nbformat-version
+      - id: remove-empty-tags
       - id: set-nb-cells
         args:
           - --add-install-cell

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -30,6 +30,7 @@
     "ms-python.flake8",
     "ms-python.isort",
     "ms-python.pylint",
+    "ms-toolsai.vscode-jupyter-slideshow",
     "travisillig.vscode-json-stable-stringify",
     "tyriar.sort-lines"
   ]

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -10,9 +10,6 @@
     "jupyter": {
      "source_hidden": true
     },
-    "slideshow": {
-     "slide_type": "skip"
-    },
     "tags": [
      "remove-cell",
      "skip-execution"
@@ -33,9 +30,6 @@
     "hidePrompt": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": "skip"
     },
     "tags": [
      "remove-cell"
@@ -87,9 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### Investigate intermediate resonances"
    ]
@@ -97,9 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import qrules\n",
@@ -168,9 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import qrules\n",
@@ -192,9 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "subset = pdg.filter(lambda p: p.spin in {2.5, 3.5, 4.5} and p.name.startswith(\"N\"))\n",

--- a/docs/usage/conservation.ipynb
+++ b/docs/usage/conservation.ipynb
@@ -10,9 +10,6 @@
     "jupyter": {
      "source_hidden": true
     },
-    "slideshow": {
-     "slide_type": "skip"
-    },
     "tags": [
      "remove-cell",
      "skip-execution"
@@ -33,9 +30,6 @@
     "hidePrompt": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": "skip"
     },
     "tags": [
      "remove-cell"
@@ -149,9 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### No spin and angular momentum"
    ]

--- a/docs/usage/custom-topology.ipynb
+++ b/docs/usage/custom-topology.ipynb
@@ -10,9 +10,6 @@
     "jupyter": {
      "source_hidden": true
     },
-    "slideshow": {
-     "slide_type": "skip"
-    },
     "tags": [
      "remove-cell",
      "skip-execution"
@@ -33,9 +30,6 @@
     "hidePrompt": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": "skip"
     },
     "tags": [
      "remove-cell"

--- a/docs/usage/ls-coupling.ipynb
+++ b/docs/usage/ls-coupling.ipynb
@@ -10,9 +10,6 @@
     "jupyter": {
      "source_hidden": true
     },
-    "slideshow": {
-     "slide_type": "skip"
-    },
     "tags": [
      "remove-cell",
      "skip-execution"
@@ -33,9 +30,6 @@
     "hidePrompt": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": "skip"
     },
     "tags": [
      "remove-cell"

--- a/docs/usage/particle.ipynb
+++ b/docs/usage/particle.ipynb
@@ -10,9 +10,6 @@
     "jupyter": {
      "source_hidden": true
     },
-    "slideshow": {
-     "slide_type": "skip"
-    },
     "tags": [
      "remove-cell",
      "skip-execution"
@@ -33,9 +30,6 @@
     "hidePrompt": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": "skip"
     },
     "tags": [
      "remove-cell"

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -10,9 +10,6 @@
     "jupyter": {
      "source_hidden": true
     },
-    "slideshow": {
-     "slide_type": "skip"
-    },
     "tags": [
      "remove-cell",
      "skip-execution"
@@ -33,9 +30,6 @@
     "hidePrompt": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": "skip"
     },
     "tags": [
      "remove-cell"
@@ -489,9 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "stm.set_allowed_intermediate_particles(r\"f\\([02]\\)\", regex=True)\n",
@@ -585,9 +577,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "```{tip}\n",
     "The {mod}`ampform` package can formulate amplitude models based on the state transitions created by {mod}`qrules`. See {doc}`ampform:usage/amplitude`.\n",

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -10,9 +10,6 @@
     "jupyter": {
      "source_hidden": true
     },
-    "slideshow": {
-     "slide_type": "skip"
-    },
     "tags": [
      "remove-cell",
      "skip-execution"
@@ -33,9 +30,6 @@
     "hidePrompt": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": "skip"
     },
     "tags": [
      "remove-cell"


### PR DESCRIPTION
Remove `editable` and `slideshow` metadata from cell metadata in notebooks. See https://github.com/ComPWA/qrules/pull/274#discussion_r1668687537.