### PR TITLE
FIX: switch back to `python-constraint`

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -121,7 +121,7 @@ pytest==8.3.2
 pytest-cov==5.0.0
 pytest-profiling==1.7.0
 pytest-xdist==3.6.1
-python-constraint2==2.0.0b5
+python-constraint==1.4.0
 python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
 python-lsp-jsonrpc==1.1.2

--- a/.constraints/py3.11.txt
+++ b/.constraints/py3.11.txt
@@ -120,7 +120,7 @@ pytest==8.3.2
 pytest-cov==5.0.0
 pytest-profiling==1.7.0
 pytest-xdist==3.6.1
-python-constraint2==2.0.0b5
+python-constraint==1.4.0
 python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
 python-lsp-jsonrpc==1.1.2

--- a/.constraints/py3.12.txt
+++ b/.constraints/py3.12.txt
@@ -120,7 +120,7 @@ pytest==8.3.2
 pytest-cov==5.0.0
 pytest-profiling==1.7.0
 pytest-xdist==3.6.1
-python-constraint2==2.0.0b5
+python-constraint==1.4.0
 python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
 python-lsp-jsonrpc==1.1.2

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -126,7 +126,7 @@ pytest==8.3.2
 pytest-cov==5.0.0
 pytest-profiling==1.7.0
 pytest-xdist==3.6.1
-python-constraint2==2.0.0b5
+python-constraint==1.4.0
 python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
 python-lsp-jsonrpc==1.1.2

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -121,7 +121,7 @@ pytest==8.3.2
 pytest-cov==5.0.0
 pytest-profiling==1.7.0
 pytest-xdist==3.6.1
-python-constraint2==2.0.0b5
+python-constraint==1.4.0
 python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
 python-lsp-jsonrpc==1.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,8 @@ dependencies = [
     "attrs >=20.1.0", # on_setattr and https://www.attrs.org/en/stable/api.html#next-gen
     "jsonschema",
     "particle",
+    "python-constraint",
     "tqdm >=4.24.0", # autonotebook
-    'python-constraint2; python_version >="3.8.0"',
-    'python-constraint; python_version <"3.8.0"',
     'typing-extensions; python_version <"3.8.0"', # Literal, Protocol
 ]
 description = "Rule-based particle reaction problem solver on a quantum number level"


### PR DESCRIPTION
This PR addresses https://github.com/ComPWA/qrules/issues/293, but only for the 0.10.x releases. It's required for https://github.com/ComPWA/policy/issues/333, which locks the environment with `uv` in downstream packages like AmpForm.