### PR TITLE
FIX: support Python 3.9 again

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -193,7 +193,6 @@
     "pyplot",
     "pytest",
     "qrules",
-    "redef",
     "setuptools",
     "spflueger",
     "struct",

--- a/.cspell.json
+++ b/.cspell.json
@@ -193,6 +193,7 @@
     "pyplot",
     "pytest",
     "qrules",
+    "redef",
     "setuptools",
     "spflueger",
     "struct",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: https://github.com/ComPWA/policy
-    rev: 0.5.15
+    rev: 0.5.16
     hooks:
       - id: check-dev-files
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -537,10 +537,3 @@ commands = [
     ],
 ]
 description = "Run ALL tests, including the slow channel tests, and compute coverage"
-
-[tool.uv]
-constraint-dependencies = [
-    "pygments!=2.19.*", # https://github.com/felix-hilden/sphinx-codeautolink/issues/152
-    "pytest-profiling!=1.8.0",
-    "sphinx-codeautolink!=0.16.0",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,8 +137,6 @@ namespaces = false
 where = ["src"]
 
 [tool.setuptools_scm]
-local_scheme = "no-local-version"
-version_scheme = "only-version"
 write_to = "src/qrules/version.py"
 
 [tool.coverage.run]

--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 import logging
 import re
 import string
+import sys
 from collections import abc
 from fractions import Fraction
 from functools import singledispatch
 from inspect import isfunction
-from types import NoneType
 from typing import TYPE_CHECKING, Any, cast
 
 import attrs
@@ -24,6 +24,10 @@ from qrules.quantum_numbers import InteractionProperties
 from qrules.solving import EdgeSettings, NodeSettings, QNProblemSet, QNResult
 from qrules.topology import FrozenTransition, MutableTransition, Topology, Transition
 from qrules.transition import ProblemSet, ReactionInfo, State
+
+if sys.version_info >= (3, 10):
+    from types import NoneType
+
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -299,19 +303,26 @@ def as_string(obj: Any) -> str:
     >>> as_string(10)
     'new int rendering'
     """
-    _LOGGER.warning(f"No DOT renderer implemented type {type(obj).__name__}")
+    if obj is not None:
+        _LOGGER.warning(f"No DOT renderer implemented type {type(obj).__name__}")
     return str(obj)
 
 
-@as_string.register(NoneType)
-@as_string.register(int)
+if sys.version_info >= (3, 10):
+
+    @as_string.register(NoneType)
+    def _(obj: Any) -> str:
+        return str(obj)
+
+
+@as_string.register(int)  # type: ignore[no-redef]
 @as_string.register(float)
 @as_string.register(str)
 def _(obj: Any) -> str:
     return str(obj)
 
 
-@as_string.register(dict)
+@as_string.register(dict)  # type: ignore[no-redef]
 def _(obj: dict) -> str:
     lines = []
     for key, value in obj.items():
@@ -334,7 +345,7 @@ def __render_key_and_value(key: str, value: Any) -> str:
     return as_string(value)
 
 
-@as_string.register(InteractionProperties)
+@as_string.register(InteractionProperties)  # type: ignore[no-redef]
 def _(obj: InteractionProperties) -> str:
     lines = []
     if obj.l_magnitude is not None:
@@ -355,7 +366,7 @@ def _(obj: InteractionProperties) -> str:
     return "\n".join(lines)
 
 
-@as_string.register(EdgeSettings)
+@as_string.register(EdgeSettings)  # type: ignore[no-redef]
 @as_string.register(NodeSettings)
 def _(settings: EdgeSettings | NodeSettings) -> str:
     output = ""
@@ -418,7 +429,7 @@ def __render_domain(domain: list[Any], key: str) -> str:
     return "[" + ", ".join(domain_str) + "]"
 
 
-@as_string.register(Particle)
+@as_string.register(Particle)  # type: ignore[no-redef]
 def _(particle: Particle) -> str:
     return particle.name
 
@@ -437,7 +448,7 @@ def _state_to_str(state: State) -> str:
     return f"{particle}[{spin_projection}]"
 
 
-@as_string.register(tuple)
+@as_string.register(tuple)  # type: ignore[no-redef]
 def _(obj: tuple) -> str:
     if len(obj) == 2:
         if isinstance(obj[0], Particle) and isinstance(obj[1], (Fraction, float, int)):

--- a/src/qrules/io/_dot.py
+++ b/src/qrules/io/_dot.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 import re
 import string
-import sys
 from collections import abc
 from fractions import Fraction
 from functools import singledispatch
@@ -24,10 +23,6 @@ from qrules.quantum_numbers import InteractionProperties
 from qrules.solving import EdgeSettings, NodeSettings, QNProblemSet, QNResult
 from qrules.topology import FrozenTransition, MutableTransition, Topology, Transition
 from qrules.transition import ProblemSet, ReactionInfo, State
-
-if sys.version_info >= (3, 10):
-    from types import NoneType
-
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -308,21 +303,14 @@ def as_string(obj: Any) -> str:
     return str(obj)
 
 
-if sys.version_info >= (3, 10):
-
-    @as_string.register(NoneType)
-    def _(obj: Any) -> str:
-        return str(obj)
-
-
-@as_string.register(int)  # type: ignore[no-redef]
+@as_string.register(int)
 @as_string.register(float)
 @as_string.register(str)
 def _(obj: Any) -> str:
     return str(obj)
 
 
-@as_string.register(dict)  # type: ignore[no-redef]
+@as_string.register(dict)
 def _(obj: dict) -> str:
     lines = []
     for key, value in obj.items():
@@ -345,7 +333,7 @@ def __render_key_and_value(key: str, value: Any) -> str:
     return as_string(value)
 
 
-@as_string.register(InteractionProperties)  # type: ignore[no-redef]
+@as_string.register(InteractionProperties)
 def _(obj: InteractionProperties) -> str:
     lines = []
     if obj.l_magnitude is not None:
@@ -366,7 +354,7 @@ def _(obj: InteractionProperties) -> str:
     return "\n".join(lines)
 
 
-@as_string.register(EdgeSettings)  # type: ignore[no-redef]
+@as_string.register(EdgeSettings)
 @as_string.register(NodeSettings)
 def _(settings: EdgeSettings | NodeSettings) -> str:
     output = ""
@@ -429,7 +417,7 @@ def __render_domain(domain: list[Any], key: str) -> str:
     return "[" + ", ".join(domain_str) + "]"
 
 
-@as_string.register(Particle)  # type: ignore[no-redef]
+@as_string.register(Particle)
 def _(particle: Particle) -> str:
     return particle.name
 
@@ -448,7 +436,7 @@ def _state_to_str(state: State) -> str:
     return f"{particle}[{spin_projection}]"
 
 
-@as_string.register(tuple)  # type: ignore[no-redef]
+@as_string.register(tuple)
 def _(obj: tuple) -> str:
     if len(obj) == 2:
         if isinstance(obj[0], Particle) and isinstance(obj[1], (Fraction, float, int)):

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -330,6 +330,6 @@ def _compute_hash(obj) -> str:
 
 
 def _to_bytes(obj) -> bytes:
-    if isinstance(obj, bytes | bytearray):
+    if isinstance(obj, (bytes, bytearray)):
         return obj
     return pickle.dumps(obj)

--- a/tests/unit/test_transition.py
+++ b/tests/unit/test_transition.py
@@ -1,6 +1,7 @@
 # pyright: reportUnusedImport=false
 import hashlib
 import pickle  # noqa: S403
+import sys
 from copy import deepcopy
 from fractions import Fraction
 
@@ -47,10 +48,17 @@ class TestReactionInfo:
         assert hash(deepcopy(reaction)) == hash(reaction)
 
     def test_hash_value(self, reaction: ReactionInfo):
-        expected_hash = {
-            "canonical-helicity": "65106a44301f9340e633d09f66ad7d17",
-            "helicity": "9646d3ee5c5e8534deb8019435161f2e",
-        }[reaction.formalism]
+        if sys.version_info >= (3, 10):
+            expected_hash = {
+                "canonical-helicity": "65106a44301f9340e633d09f66ad7d17",
+                "helicity": "9646d3ee5c5e8534deb8019435161f2e",
+            }[reaction.formalism]
+        else:
+            expected_hash = {
+                "canonical-helicity": "0d8bc378677986e0dc2d3b02f5627e0b",
+                "helicity": "71404ad43550850a02109e8db044bd28",
+            }[reaction.formalism]
+
         assert _compute_hash(reaction) == expected_hash
 
 

--- a/tests/unit/test_transition.py
+++ b/tests/unit/test_transition.py
@@ -48,7 +48,7 @@ class TestReactionInfo:
         assert hash(deepcopy(reaction)) == hash(reaction)
 
     def test_hash_value(self, reaction: ReactionInfo):
-        if sys.version_info >= (3, 10):
+        if sys.version_info >= (3, 11):
             expected_hash = {
                 "canonical-helicity": "65106a44301f9340e633d09f66ad7d17",
                 "helicity": "9646d3ee5c5e8534deb8019435161f2e",

--- a/tests/unit/test_transition.py
+++ b/tests/unit/test_transition.py
@@ -124,6 +124,6 @@ def _compute_hash(obj) -> str:
 
 
 def _to_bytes(obj) -> bytes:
-    if isinstance(obj, bytes | bytearray):
+    if isinstance(obj, (bytes, bytearray)):
         return obj
     return pickle.dumps(obj)

--- a/uv.lock
+++ b/uv.lock
@@ -6,13 +6,6 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 
-[manifest]
-constraints = [
-    { name = "pygments", specifier = "!=2.19.*" },
-    { name = "pytest-profiling", specifier = "!=1.8.0" },
-    { name = "sphinx-codeautolink", specifier = "!=0.16.0" },
-]
-
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"

--- a/uv.lock
+++ b/uv.lock
@@ -1800,11 +1800,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.18.0"
+version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
 ]
 
 [[package]]


### PR DESCRIPTION
Since the current scheme of overloading `as_string` depends on the `NoneType` (introduced in Python 3.10), a workaround with conditional loading of the  `types`-module had to be implemented to support Python 3.9.

Updates in this PR are related to these issues:
- https://github.com/ComPWA/actions/issues/124
- https://github.com/ComPWA/policy/issues/493
- https://github.com/ComPWA/policy/issues/490
