### PR TITLE
FEAT: add markdown support for mermaid

### DIFF
--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -172,12 +172,9 @@
     "    render_final_state_id=False,\n",
     "    render_resonance_id=True,\n",
     "    render_node=False,\n",
+    "    markdown=True,\n",
     ")\n",
-    "Markdown(f\"\"\"\n",
-    "```mermaid\n",
-    "{source}\n",
-    "```\n",
-    "\"\"\")"
+    "Markdown(source)"
    ]
   },
   {
@@ -261,12 +258,8 @@
    },
    "outputs": [],
    "source": [
-    "source = qrules.io.asmermaid(problem_set, render_node=True)\n",
-    "Markdown(f\"\"\"\n",
-    "```mermaid\n",
-    "{source}\n",
-    "```\n",
-    "\"\"\")"
+    "source = qrules.io.asmermaid(problem_set, render_node=True, markdown=True)\n",
+    "Markdown(source)"
    ]
   },
   {
@@ -459,12 +452,8 @@
    },
    "outputs": [],
    "source": [
-    "source = qrules.io.asmermaid(qn_problem_set, render_node=True)\n",
-    "Markdown(f\"\"\"\n",
-    "```mermaid\n",
-    "{source}\n",
-    "```\n",
-    "\"\"\")"
+    "source = qrules.io.asmermaid(qn_problem_set, render_node=True, markdown=True)\n",
+    "Markdown(source)"
    ]
   },
   {
@@ -484,12 +473,8 @@
    },
    "outputs": [],
    "source": [
-    "source = qrules.io.asmermaid(filtered_qn_result, render_node=True)\n",
-    "Markdown(f\"\"\"\n",
-    "```mermaid\n",
-    "{source}\n",
-    "```\n",
-    "\"\"\")"
+    "source = qrules.io.asmermaid(filtered_qn_result, render_node=True, markdown=True)\n",
+    "Markdown(source)"
    ]
   },
   {
@@ -669,12 +654,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "source = qrules.io.asmermaid(reaction, collapse_graphs=True, render_node=False)\n",
-    "Markdown(f\"\"\"\n",
-    "```mermaid\n",
-    "{source}\n",
-    "```\n",
-    "\"\"\")"
+    "source = qrules.io.asmermaid(\n",
+    "    reaction, collapse_graphs=True, render_node=False, markdown=True\n",
+    ")\n",
+    "Markdown(source)"
    ]
   },
   {
@@ -893,12 +876,9 @@
     "        \"fill\": \"lightgray\",\n",
     "        \"stroke\": \"black\",\n",
     "    },\n",
+    "    markdown=True,\n",
     ")\n",
-    "Markdown(f\"\"\"\n",
-    "```mermaid\n",
-    "{source}\n",
-    "```\n",
-    "\"\"\")"
+    "Markdown(source)"
    ]
   }
  ],

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -134,6 +134,7 @@ def asmermaid(
     figure_style: dict[str, Any] | None = None,
     edge_style: dict[str, Any] | None = None,
     node_style: dict[str, Any] | None = None,
+    markdown: bool = False,
 ) -> str:
     """Convert a `object` to a Mermaid flowchart source `str`.
 
@@ -168,6 +169,8 @@ def asmermaid(
         node_style: Styling of Mermaid nodes.
         figure_style: Styling of the whole Mermaid diagram.
 
+        markdown: Wrap the Mermaid source in a Markdown code fence.
+
     .. seealso::
 
         See the
@@ -187,7 +190,10 @@ def asmermaid(
         edge_style=edge_style,
         node_style=node_style,
     )
-    return print_mermaid(instance)
+    source = print_mermaid(instance)
+    if markdown:
+        return f"```mermaid\n{source}```\n"
+    return source
 
 
 def load(filename: str | Path) -> object:

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -173,9 +173,9 @@ def asmermaid(
 
     .. seealso::
 
-        See the
-        `Mermaid flowchart syntax <https://mermaid.ai/open-source/syntax/flowchart.html>`_
-        for available diagram constructs and style directives.
+        See the `Mermaid flowchart syntax
+        <https://mermaid.ai/open-source/syntax/flowchart.html>`_ for available diagram
+        constructs and style directives.
 
     .. seealso:: :doc:`/usage/visualize`
     """

--- a/tests/unit/io/test_mermaid.py
+++ b/tests/unit/io/test_mermaid.py
@@ -38,6 +38,13 @@ def test_asmermaid_api():
     assert " --- " in src
 
 
+def test_asmermaid_markdown_fence():
+    topology = create_n_body_topology(3, 4)
+    src = io.asmermaid(topology, markdown=True)
+    assert src.startswith("```mermaid\nflowchart LR\n")
+    assert src.endswith("\n```\n")
+
+
 def test_asmermaid_accepts_style_parameters():
     topology = create_n_body_topology(3, 4)
     src = io.asmermaid(


### PR DESCRIPTION
Closes #352

## ✨ New features

- `qrules.io.asmermaid()` now takes an optional `markdown` flag. When set to `True`, the returned Mermaid source is wrapped in a ` ```mermaid ` code fence, so the result can be handed straight to `IPython.display.Markdown` (or written into a Markdown file) without manually building the fence around it.