### PR TITLE
FEAT: add LaTeX rendering for Mermaid labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,12 @@ TAGS
 pyvenv*/
 
 # Settings
+.agents/
 .claude/
 .idea/
+.pr_body.md
 **.code-workspace
+AGENTS.md
 CLAUDE.md
 
 # Exceptions

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,6 +9,7 @@
     "github.vscode-github-actions",
     "github.vscode-pull-request-github",
     "joaompinto.vscode-graphviz",
+    "mermaidchart.vscode-mermaid-chart",
     "mhutchie.git-graph",
     "ms-python.mypy-type-checker",
     "ms-python.python",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -241,6 +241,7 @@ html_theme_options = {
     "show_toc_level": 2,
     "use_download_button": False,
     "use_edit_page_button": True,
+    "use_fullscreen_button": False,
     "use_issues_button": True,
     "use_repository_button": True,
     "use_source_button": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,6 +147,8 @@ exclude_patterns = [
     "**.ipynb_checkpoints",
     "**.virtual_documents",
     "*build",
+    "AGENTS.md",
+    "CLAUDE.md",
     "adr/template.md",
     "tests",
 ]

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -880,6 +880,23 @@
     ")\n",
     "Markdown(source)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible in Mermaid to render labels with LaTeX like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source = qrules.io.asmermaid(problem_set, render_node=True, latex=True, markdown=True)\n",
+    "Markdown(source)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -253,8 +253,8 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-input",
-     "full-width"
+     "full-width",
+     "hide-input"
     ]
    },
    "outputs": [],
@@ -448,8 +448,8 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-input",
-     "full-width"
+     "full-width",
+     "hide-input"
     ]
    },
    "outputs": [],

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -253,7 +253,8 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-input"
+     "hide-input",
+     "full-width"
     ]
    },
    "outputs": [],
@@ -447,7 +448,8 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-input"
+     "hide-input",
+     "full-width"
     ]
    },
    "outputs": [],
@@ -885,7 +887,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is also possible in Mermaid to render labels with LaTeX like this:"
+    "As default Mermaid renders labels with LaTeX. This can also disabled with the `latex` argument of {func}`.asmermaid`:"
    ]
   },
   {
@@ -894,7 +896,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "source = qrules.io.asmermaid(problem_set, render_node=True, latex=True, markdown=True)\n",
+    "source = qrules.io.asmermaid(problem_set, render_node=True, latex=False, markdown=True)\n",
     "Markdown(source)"
    ]
   }

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -134,7 +134,7 @@ def asmermaid(
     figure_style: dict[str, Any] | None = None,
     edge_style: dict[str, Any] | None = None,
     node_style: dict[str, Any] | None = None,
-    latex: bool = False,
+    latex: bool = True,
     markdown: bool = False,
 ) -> str:
     """Convert a `object` to a Mermaid flowchart source `str`.

--- a/src/qrules/io/__init__.py
+++ b/src/qrules/io/__init__.py
@@ -134,6 +134,7 @@ def asmermaid(
     figure_style: dict[str, Any] | None = None,
     edge_style: dict[str, Any] | None = None,
     node_style: dict[str, Any] | None = None,
+    latex: bool = False,
     markdown: bool = False,
 ) -> str:
     """Convert a `object` to a Mermaid flowchart source `str`.
@@ -169,6 +170,8 @@ def asmermaid(
         node_style: Styling of Mermaid nodes.
         figure_style: Styling of the whole Mermaid diagram.
 
+        latex: Render edge and node labels as LaTeX math expressions. Particle labels
+            use `.Particle.latex` when available.
         markdown: Wrap the Mermaid source in a Markdown code fence.
 
     .. seealso::
@@ -189,6 +192,7 @@ def asmermaid(
         figure_style=figure_style,
         edge_style=edge_style,
         node_style=node_style,
+        latex=latex,
     )
     source = print_mermaid(instance)
     if markdown:

--- a/src/qrules/io/_labels.py
+++ b/src/qrules/io/_labels.py
@@ -115,12 +115,6 @@ def as_latex(obj: Any) -> str:
     labels independently of the plain-text labels produced by `.as_string`. If no
     specialized implementation exists, the object is converted to a `str` and a warning
     is emitted.
-
-    Args:
-        obj: Edge or node property to render.
-
-    Returns:
-        LaTeX source representing the supplied property.
     """
     if obj is not None:
         _LOGGER.warning(

--- a/src/qrules/io/_labels.py
+++ b/src/qrules/io/_labels.py
@@ -5,7 +5,7 @@ import re
 from fractions import Fraction
 from functools import singledispatch
 from inspect import isfunction
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import attrs
 
@@ -122,6 +122,121 @@ def as_latex(obj: Any) -> str:
     return str(obj)
 
 
+class _LabelFormatter(Protocol):
+    def render(self, obj: Any) -> str: ...
+
+    def text(self, value: str) -> str: ...
+
+    def fraction(self, value: Fraction, *, plusminus: bool = False) -> str: ...
+
+    def lines(self, values: list[str]) -> str: ...
+
+    def domain(self, values: list[str]) -> str: ...
+
+    def assignment(self, key: str, value: str, *, compact: bool = False) -> str: ...
+
+    def membership(self, key: str, domain: str) -> str: ...
+
+    def particle(self, name: str, latex: str | None) -> str: ...
+
+    def spin(self, magnitude: str, projection: str) -> str: ...
+
+    def state(self, particle: str, projection: str) -> str: ...
+
+
+class _PlainFormatter:
+    @staticmethod
+    def render(obj: Any) -> str:
+        return as_string(obj)
+
+    @staticmethod
+    def text(value: str) -> str:
+        return str(value)
+
+    @staticmethod
+    def fraction(value: Fraction, *, plusminus: bool = False) -> str:
+        return _render_fraction(value, plusminus=plusminus)
+
+    @staticmethod
+    def lines(values: list[str]) -> str:
+        return "\n".join(values)
+
+    @staticmethod
+    def domain(values: list[str]) -> str:
+        return f"[{', '.join(values)}]"
+
+    @staticmethod
+    def assignment(key: str, value: str, *, compact: bool = False) -> str:
+        separator = "=" if compact else " = "
+        return f"{key}{separator}{value}"
+
+    @staticmethod
+    def membership(key: str, domain: str) -> str:
+        return f"{key} ∊ {domain}"
+
+    @staticmethod
+    def particle(name: str, latex: str | None) -> str:
+        del latex
+        return name
+
+    @staticmethod
+    def spin(magnitude: str, projection: str) -> str:
+        return f"|{magnitude},{projection}⟩"
+
+    @staticmethod
+    def state(particle: str, projection: str) -> str:
+        return f"{particle}[{projection}]"
+
+
+class _LatexFormatter:
+    @staticmethod
+    def render(obj: Any) -> str:
+        return as_latex(obj)
+
+    @staticmethod
+    def text(value: str) -> str:
+        return Rf"\text{{{_escape_latex_text(value)}}}"
+
+    @staticmethod
+    def fraction(value: Fraction, *, plusminus: bool = False) -> str:
+        return _render_latex_fraction(value, plusminus=plusminus)
+
+    @staticmethod
+    def lines(values: list[str]) -> str:
+        return _render_latex_lines(values)
+
+    @staticmethod
+    def domain(values: list[str]) -> str:
+        return R"\left[" + ", ".join(values) + R"\right]"
+
+    @staticmethod
+    def assignment(key: str, value: str, *, compact: bool = False) -> str:
+        del compact
+        return f"{key} = {value}"
+
+    @staticmethod
+    def membership(key: str, domain: str) -> str:
+        return Rf"{key} \in {domain}"
+
+    @staticmethod
+    def particle(name: str, latex: str | None) -> str:
+        if latex:
+            return latex
+        return _LatexFormatter.text(name)
+
+    @staticmethod
+    def spin(magnitude: str, projection: str) -> str:
+        return Rf"\left|{magnitude},{projection}\right\rangle"
+
+    @staticmethod
+    def state(particle: str, projection: str) -> str:
+        return Rf"{particle}\left[{projection}\right]"
+
+
+_PLAIN_FORMATTER = _PlainFormatter()
+_LATEX_FORMATTER = _LatexFormatter()
+
+
 @as_latex.register(int)
 @as_latex.register(float)
 @as_latex.register(str)
@@ -134,7 +249,7 @@ def _(obj: Any) -> str:
 
 @as_latex.register(Fraction)
 def _(value: Fraction) -> str:
-    return __render_latex_fraction(value)
+    return _render_latex_fraction(value)
 
 
 @as_latex.register(type(None))
@@ -144,21 +259,15 @@ def _(_: None) -> str:
 
 @as_string.register(dict)
 def _(obj: dict) -> str:
-    lines = []
-    for key, value in obj.items():
-        if isinstance(key, type) or callable(key):
-            key_repr = key.__name__
-        else:
-            key_repr = key
-        if not value and not key_repr.endswith(("magnitude", "projection")):
-            continue
-        value_repr = __render_key_and_value(key_repr, value)
-        lines.append(f"{key_repr} = {value_repr}")
-    return "\n".join(lines)
+    return __render_mapping(obj, _PLAIN_FORMATTER)
 
 
 @as_latex.register(dict)
 def _(obj: dict) -> str:
+    return __render_mapping(obj, _LATEX_FORMATTER)
+
+
+def __render_mapping(obj: dict, formatter: _LabelFormatter) -> str:
     lines: list[str] = []
     for key, value in obj.items():
         if isinstance(key, type) or callable(key):
@@ -167,27 +276,24 @@ def _(obj: dict) -> str:
             key_repr = str(key)
         if not value and not key_repr.endswith(("magnitude", "projection")):
             continue
-        value_repr = __render_latex_key_and_value(key_repr, value)
-        lines.append(Rf"\text{{{__escape_latex_text(key_repr)}}} = {value_repr}")
-    return __render_latex_lines(lines)
+        value_repr = __render_key_and_value(key_repr, value, formatter)
+        lines.append(formatter.assignment(formatter.text(key_repr), value_repr))
+    return formatter.lines(lines)
 
 
-def __render_key_and_value(key: str, value: Any) -> str:
+def __render_key_and_value(
+    key: str,
+    value: Any,
+    formatter: _LabelFormatter = _PLAIN_FORMATTER,
+) -> str:
     if isinstance(value, (Fraction, int)):
         fraction = Fraction(value)
         no_pm = key.endswith("magnitude") or key == "pid"
-        return _render_fraction(fraction, plusminus=not no_pm)
-    return as_string(value)
+        return formatter.fraction(fraction, plusminus=not no_pm)
+    return formatter.render(value)
 
 
-def __render_latex_key_and_value(key: str, value: Any) -> str:
-    if isinstance(value, (Fraction, int)):
-        no_pm = key.endswith("magnitude") or key == "pid"
-        return __render_latex_fraction(Fraction(value), plusminus=not no_pm)
-    return as_latex(value)
-
-
-def __render_latex_fraction(value: Fraction, *, plusminus: bool = False) -> str:
+def _render_latex_fraction(value: Fraction, *, plusminus: bool = False) -> str:
     sign = ""
     if value < 0:
         sign = "-"
@@ -199,11 +305,11 @@ def __render_latex_fraction(value: Fraction, *, plusminus: bool = False) -> str:
     return Rf"{sign}\frac{{{value.numerator}}}{{{value.denominator}}}"
 
 
-def __escape_latex_text(text: str) -> str:
+def _escape_latex_text(text: str) -> str:
     return str(text).translate(_LATEX_TEXT_ESCAPES)
 
 
-def __render_latex_lines(lines: list[str]) -> str:
+def _render_latex_lines(lines: list[str]) -> str:
     if not lines:
         return ""
     if len(lines) == 1:
@@ -214,91 +320,69 @@ def __render_latex_lines(lines: list[str]) -> str:
 
 @as_string.register(InteractionProperties)
 def _(obj: InteractionProperties) -> str:
-    lines = []
-    if obj.l_magnitude is not None:
-        if obj.l_projection is None:
-            l_label = _render_fraction(Fraction(obj.l_magnitude))
-        else:
-            l_label = _spin_to_str(Spin(obj.l_magnitude, obj.l_projection))
-        lines.append(f"L={l_label}")
-    if obj.s_magnitude is not None:
-        if obj.s_projection is None:
-            s_label = _render_fraction(Fraction(obj.s_magnitude))
-        else:
-            s_label = _spin_to_str(Spin(obj.s_magnitude, obj.s_projection))
-        lines.append(f"S={s_label}")
-    if obj.parity_prefactor is not None:
-        label = _render_fraction(Fraction(obj.parity_prefactor), plusminus=True)
-        lines.append(f"P={label}")
-    return "\n".join(lines)
+    return __render_interaction(obj, _PLAIN_FORMATTER)
 
 
 @as_latex.register(InteractionProperties)
 def _(obj: InteractionProperties) -> str:
+    return __render_interaction(obj, _LATEX_FORMATTER)
+
+
+def __render_interaction(obj: InteractionProperties, formatter: _LabelFormatter) -> str:
     lines: list[str] = []
     if obj.l_magnitude is not None:
         if obj.l_projection is None:
-            l_label = __render_latex_fraction(Fraction(obj.l_magnitude))
+            l_label = formatter.fraction(Fraction(obj.l_magnitude))
         else:
-            l_label = as_latex(Spin(obj.l_magnitude, obj.l_projection))
-        lines.append(f"L = {l_label}")
+            l_label = formatter.render(Spin(obj.l_magnitude, obj.l_projection))
+        lines.append(formatter.assignment("L", l_label, compact=True))
     if obj.s_magnitude is not None:
         if obj.s_projection is None:
-            s_label = __render_latex_fraction(Fraction(obj.s_magnitude))
+            s_label = formatter.fraction(Fraction(obj.s_magnitude))
         else:
-            s_label = as_latex(Spin(obj.s_magnitude, obj.s_projection))
-        lines.append(f"S = {s_label}")
+            s_label = formatter.render(Spin(obj.s_magnitude, obj.s_projection))
+        lines.append(formatter.assignment("S", s_label, compact=True))
     if obj.parity_prefactor is not None:
-        label = __render_latex_fraction(Fraction(obj.parity_prefactor), plusminus=True)
-        lines.append(f"P = {label}")
-    return __render_latex_lines(lines)
+        label = formatter.fraction(Fraction(obj.parity_prefactor), plusminus=True)
+        lines.append(formatter.assignment("P", label, compact=True))
+    return formatter.lines(lines)
 
 
 @as_string.register(EdgeSettings)
 @as_string.register(NodeSettings)
 def _(settings: EdgeSettings | NodeSettings) -> str:
-    output = ""
-    if settings.rule_priorities:
-        output += "RULES\n"
-        rule_descriptions = (
-            f"{__render_rule(rule)} - {__get_priority(rule, settings.rule_priorities)}"
-            for rule in settings.conservation_rules
-        )
-        sorted_names = sorted(rule_descriptions, key=__extract_priority, reverse=True)
-        output += "\n".join(sorted_names)
-    if settings.qn_domains:
-        if output:
-            output += "\n"
-        domains = sorted(
-            f"{qn.__name__} ∊ {__render_domain(domain, key=qn.__name__)}"
-            for qn, domain in settings.qn_domains.items()
-        )
-        output += "DOMAINS\n"
-        output += "\n".join(domains)
-    return output
+    return __render_settings(settings, _PLAIN_FORMATTER)
 
 
 @as_latex.register(EdgeSettings)
 @as_latex.register(NodeSettings)
 def _(settings: EdgeSettings | NodeSettings) -> str:
+    return __render_settings(settings, _LATEX_FORMATTER)
+
+
+def __render_settings(
+    settings: EdgeSettings | NodeSettings, formatter: _LabelFormatter
+) -> str:
     lines: list[str] = []
     if settings.rule_priorities:
-        lines.append(R"\text{RULES}")
+        lines.append(formatter.text("RULES"))
         rule_descriptions = (
             f"{__render_rule(rule)} - {__get_priority(rule, settings.rule_priorities)}"
             for rule in settings.conservation_rules
         )
         sorted_names = sorted(rule_descriptions, key=__extract_priority, reverse=True)
-        lines.extend(Rf"\text{{{__escape_latex_text(name)}}}" for name in sorted_names)
+        lines.extend(formatter.text(name) for name in sorted_names)
     if settings.qn_domains:
-        lines.append(R"\text{DOMAINS}")
+        lines.append(formatter.text("DOMAINS"))
         domains = sorted(
-            Rf"\text{{{__escape_latex_text(qn.__name__)}}} \in "
-            + __render_latex_domain(domain, key=qn.__name__)
+            formatter.membership(
+                formatter.text(qn.__name__),
+                __render_domain(domain, key=qn.__name__, formatter=formatter),
+            )
             for qn, domain in settings.qn_domains.items()
         )
         lines.extend(domains)
-    return __render_latex_lines(lines)
+    return formatter.lines(lines)
 
 
 def __get_priority(rule: Any, rule_priorities: dict[Any, int]) -> int | str:
@@ -335,7 +419,11 @@ def __extract_priority(description: str) -> int | float:
     return int(priority)
 
 
-def __render_domain(domain: list[Any], key: str) -> str:
+def __render_domain(
+    domain: list[Any],
+    key: str,
+    formatter: _LabelFormatter = _PLAIN_FORMATTER,
+) -> str:
     """Render a domain as a `str`.
 
     >>> half = Fraction(0.5)
@@ -347,76 +435,73 @@ def __render_domain(domain: list[Any], key: str) -> str:
     '[-1, +1, None]'
     """
     domain = sorted(domain, key=lambda x: +9999 if x is None else x)
-    domain_str = [__render_key_and_value(key, x) for x in domain]
-    return "[" + ", ".join(domain_str) + "]"
-
-
-def __render_latex_domain(domain: list[Any], key: str) -> str:
-    domain = sorted(domain, key=lambda x: +9999 if x is None else x)
-    domain_str = [__render_latex_key_and_value(key, x) for x in domain]
-    return R"\left[" + ", ".join(domain_str) + R"\right]"
+    domain_str = [__render_key_and_value(key, x, formatter) for x in domain]
+    return formatter.domain(domain_str)
 
 
 @as_string.register(Particle)
 def _(particle: Particle) -> str:
-    return particle.name
+    return __render_particle(particle, _PLAIN_FORMATTER)
 
 
 @as_latex.register(Particle)
 def _(particle: Particle) -> str:
-    if particle.latex:
-        return particle.latex
-    return Rf"\text{{{__escape_latex_text(particle.name)}}}"
+    return __render_particle(particle, _LATEX_FORMATTER)
+
+
+def __render_particle(particle: Particle, formatter: _LabelFormatter) -> str:
+    return formatter.particle(particle.name, particle.latex)
 
 
 @as_string.register(Spin)
-def _spin_to_str(spin: Spin) -> str:
-    spin_magnitude = _render_fraction(spin.magnitude)
-    spin_projection = _render_fraction(spin.projection, plusminus=True)
-    return f"|{spin_magnitude},{spin_projection}⟩"
+def _(spin: Spin) -> str:
+    return __render_spin(spin, _PLAIN_FORMATTER)
 
 
 @as_latex.register(Spin)
-def _spin_to_latex(spin: Spin) -> str:
-    spin_magnitude = __render_latex_fraction(spin.magnitude)
-    spin_projection = __render_latex_fraction(spin.projection, plusminus=True)
-    return Rf"\left|{spin_magnitude},{spin_projection}\right\rangle"
+def _(spin: Spin) -> str:
+    return __render_spin(spin, _LATEX_FORMATTER)
+
+
+def __render_spin(spin: Spin, formatter: _LabelFormatter) -> str:
+    spin_magnitude = formatter.fraction(spin.magnitude)
+    spin_projection = formatter.fraction(spin.projection, plusminus=True)
+    return formatter.spin(spin_magnitude, spin_projection)
 
 
 @as_string.register(State)
-def _state_to_str(state: State) -> str:
-    particle = state.particle.name
-    spin_projection = _render_fraction(state.spin_projection, plusminus=True)
-    return f"{particle}[{spin_projection}]"
+def _(state: State) -> str:
+    return __render_state(state, _PLAIN_FORMATTER)
 
 
 @as_latex.register(State)
-def _state_to_latex(state: State) -> str:
-    particle = as_latex(state.particle)
-    spin_projection = __render_latex_fraction(state.spin_projection, plusminus=True)
-    return Rf"{particle}\left[{spin_projection}\right]"
+def _(state: State) -> str:
+    return __render_state(state, _LATEX_FORMATTER)
+
+
+def __render_state(state: State, formatter: _LabelFormatter) -> str:
+    particle = formatter.render(state.particle)
+    spin_projection = formatter.fraction(state.spin_projection, plusminus=True)
+    return formatter.state(particle, spin_projection)
 
 
 @as_string.register(tuple)
 def _(obj: tuple) -> str:
-    if len(obj) == 2:
-        if isinstance(obj[0], Particle) and isinstance(obj[1], (Fraction, float, int)):
-            state = State(*obj)
-            return _state_to_str(state)
-        if all(isinstance(o, (Fraction, float, int)) for o in obj):
-            spin = Spin(*obj)
-            return _spin_to_str(spin)
-    return "\n".join(map(as_string, obj))
+    return __render_tuple(obj, _PLAIN_FORMATTER)
 
 
 @as_latex.register(tuple)
 def _(obj: tuple) -> str:
+    return __render_tuple(obj, _LATEX_FORMATTER)
+
+
+def __render_tuple(obj: tuple, formatter: _LabelFormatter) -> str:
     if len(obj) == 2:
         if isinstance(obj[0], Particle) and isinstance(obj[1], (Fraction, float, int)):
-            return _state_to_latex(State(*obj))
+            return __render_state(State(*obj), formatter)
         if all(isinstance(o, (Fraction, float, int)) for o in obj):
-            return _spin_to_latex(Spin(*obj))
-    return __render_latex_lines([as_latex(item) for item in obj])
+            return __render_spin(Spin(*obj), formatter)
+    return formatter.lines([formatter.render(item) for item in obj])
 
 
 def get_particle_graphs(

--- a/src/qrules/io/_labels.py
+++ b/src/qrules/io/_labels.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-_LATEX_TEXT_ESCAPES = str.maketrans({
+_TEXT_TO_LATEX_ESCAPES = str.maketrans({
     "\\": R"\textbackslash{}",
     "{": R"\{",
     "}": R"\}",
@@ -34,6 +34,13 @@ _LATEX_TEXT_ESCAPES = str.maketrans({
     "~": R"\textasciitilde{}",
     "^": R"\textasciicircum{}",
 })
+R"""Characters that are special within the argument of a LaTeX ``\text``.
+
+Names that `qrules` does not control, such as particle names without a ``latex`` field
+or quantum number keys, run through this table before ``._LatexFormatter.text``
+interpolates them. All ten replacements render under KaTeX as well, which is what
+``._mermaid`` passes the result to.
+"""
 
 
 def create_edge_label(
@@ -195,7 +202,7 @@ class _LatexFormatter:
 
     @staticmethod
     def text(value: str) -> str:
-        return Rf"\text{{{_escape_latex_text(value)}}}"
+        return Rf"\text{{{_escape_text_for_latex(value)}}}"
 
     @staticmethod
     def fraction(value: Fraction, *, plusminus: bool = False) -> str:
@@ -305,8 +312,8 @@ def _render_latex_fraction(value: Fraction, *, plusminus: bool = False) -> str:
     return Rf"{sign}\frac{{{value.numerator}}}{{{value.denominator}}}"
 
 
-def _escape_latex_text(text: str) -> str:
-    return str(text).translate(_LATEX_TEXT_ESCAPES)
+def _escape_text_for_latex(text: str) -> str:
+    return str(text).translate(_TEXT_TO_LATEX_ESCAPES)
 
 
 def _render_latex_lines(lines: list[str]) -> str:

--- a/src/qrules/io/_labels.py
+++ b/src/qrules/io/_labels.py
@@ -38,8 +38,10 @@ R"""Characters that are special within the argument of a LaTeX ``\text``.
 
 Names that `qrules` does not control, such as particle names without a ``latex`` field
 or quantum number keys, run through this table before ``._LatexFormatter.text``
-interpolates them. All ten replacements render under KaTeX as well, which is what
-``._mermaid`` passes the result to.
+interpolates them. The replacements are the `standard LaTeX escapes
+<https://latexref.xyz/Printing-special-characters.html>`_, which are `all supported by
+KaTeX <https://katex.org/docs/support_table>`_ as well, the renderer that ``._mermaid``
+hands the result to.
 """
 
 

--- a/src/qrules/io/_labels.py
+++ b/src/qrules/io/_labels.py
@@ -106,8 +106,8 @@ def as_latex(obj: Any) -> str:
     Implementations can be registered for specific types through
     :func:`functools.singledispatch`. This allows graph renderers to request LaTeX
     labels independently of the plain-text labels produced by `.as_string`. If no
-    specialized implementation exists, the object is converted to a `str` and a
-    warning is emitted.
+    specialized implementation exists, the object is converted to a `str` and a warning
+    is emitted.
 
     Args:
         obj: Edge or node property to render.

--- a/src/qrules/io/_labels.py
+++ b/src/qrules/io/_labels.py
@@ -16,18 +16,35 @@ from qrules.topology import FrozenTransition, MutableTransition, Topology, Trans
 from qrules.transition import ProblemSet, State
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from qrules.argument_handling import Rule
 
 _LOGGER = logging.getLogger(__name__)
+
+_LATEX_TEXT_ESCAPES = str.maketrans({
+    "\\": R"\textbackslash{}",
+    "{": R"\{",
+    "}": R"\}",
+    "$": R"\$",
+    "&": R"\&",
+    "#": R"\#",
+    "_": R"\_",
+    "%": R"\%",
+    "~": R"\textasciitilde{}",
+    "^": R"\textasciicircum{}",
+})
 
 
 def create_edge_label(
     graph: ProblemSet | QNProblemSet | Topology | Transition,
     edge_id: int,
     render_edge_id: bool,
+    *,
+    render_label: Callable[[Any], str] | None = None,
 ) -> str:
+    if render_label is None:
+        render_label = as_string
     if isinstance(graph, Topology):
         if render_edge_id:
             return str(edge_id)
@@ -40,15 +57,22 @@ def create_edge_label(
             edge_property = edge_setting
         if initial_fact:
             edge_property = initial_fact  # type: ignore[assignment]
-        return __render_edge_with_id(edge_id, edge_property, render_edge_id)
+        return __render_edge_with_id(
+            edge_id, edge_property, render_edge_id, render_label
+        )
     edge_prop = graph.states.get(edge_id)
-    return __render_edge_with_id(edge_id, edge_prop, render_edge_id)
+    return __render_edge_with_id(edge_id, edge_prop, render_edge_id, render_label)
 
 
-def __render_edge_with_id(edge_id: int, edge_prop: Any, render_edge_id: bool) -> str:
+def __render_edge_with_id(
+    edge_id: int,
+    edge_prop: Any,
+    render_edge_id: bool,
+    render_label: Callable[[Any], str],
+) -> str:
     if edge_prop is None or not edge_prop:
         return str(edge_id)
-    edge_label = as_string(edge_prop)
+    edge_label = render_label(edge_prop)
     if not render_edge_id:
         return edge_label
     if "\n" in edge_label:
@@ -75,11 +99,47 @@ def as_string(obj: Any) -> str:
     return str(obj)
 
 
+@singledispatch
+def as_latex(obj: Any) -> str:
+    """Render an edge or node property as LaTeX source.
+
+    Implementations can be registered for specific types through
+    :func:`functools.singledispatch`. This allows graph renderers to request LaTeX
+    labels independently of the plain-text labels produced by `.as_string`. If no
+    specialized implementation exists, the object is converted to a `str` and a
+    warning is emitted.
+
+    Args:
+        obj: Edge or node property to render.
+
+    Returns:
+        LaTeX source representing the supplied property.
+    """
+    if obj is not None:
+        _LOGGER.warning(
+            f"No LaTeX label renderer implemented type {type(obj).__name__}"
+        )
+    return str(obj)
+
+
+@as_latex.register(int)
+@as_latex.register(float)
+@as_latex.register(str)
 @as_string.register(int)
 @as_string.register(float)
 @as_string.register(str)
 def _(obj: Any) -> str:
     return str(obj)
+
+
+@as_latex.register(Fraction)
+def _(value: Fraction) -> str:
+    return __render_latex_fraction(value)
+
+
+@as_latex.register(type(None))
+def _(_: None) -> str:
+    return R"\mathrm{None}"
 
 
 @as_string.register(dict)
@@ -97,12 +157,59 @@ def _(obj: dict) -> str:
     return "\n".join(lines)
 
 
+@as_latex.register(dict)
+def _(obj: dict) -> str:
+    lines: list[str] = []
+    for key, value in obj.items():
+        if isinstance(key, type) or callable(key):
+            key_repr = key.__name__
+        else:
+            key_repr = str(key)
+        if not value and not key_repr.endswith(("magnitude", "projection")):
+            continue
+        value_repr = __render_latex_key_and_value(key_repr, value)
+        lines.append(Rf"\text{{{__escape_latex_text(key_repr)}}} = {value_repr}")
+    return __render_latex_lines(lines)
+
+
 def __render_key_and_value(key: str, value: Any) -> str:
     if isinstance(value, (Fraction, int)):
         fraction = Fraction(value)
         no_pm = key.endswith("magnitude") or key == "pid"
         return _render_fraction(fraction, plusminus=not no_pm)
     return as_string(value)
+
+
+def __render_latex_key_and_value(key: str, value: Any) -> str:
+    if isinstance(value, (Fraction, int)):
+        no_pm = key.endswith("magnitude") or key == "pid"
+        return __render_latex_fraction(Fraction(value), plusminus=not no_pm)
+    return as_latex(value)
+
+
+def __render_latex_fraction(value: Fraction, *, plusminus: bool = False) -> str:
+    sign = ""
+    if value < 0:
+        sign = "-"
+        value = abs(value)
+    elif plusminus and value > 0:
+        sign = "+"
+    if value.denominator == 1:
+        return f"{sign}{value.numerator}"
+    return Rf"{sign}\frac{{{value.numerator}}}{{{value.denominator}}}"
+
+
+def __escape_latex_text(text: str) -> str:
+    return str(text).translate(_LATEX_TEXT_ESCAPES)
+
+
+def __render_latex_lines(lines: list[str]) -> str:
+    if not lines:
+        return ""
+    if len(lines) == 1:
+        return lines[0]
+    content = R" \\ ".join(lines)
+    return Rf"\begin{{gathered}} {content} \end{{gathered}}"
 
 
 @as_string.register(InteractionProperties)
@@ -124,6 +231,27 @@ def _(obj: InteractionProperties) -> str:
         label = _render_fraction(Fraction(obj.parity_prefactor), plusminus=True)
         lines.append(f"P={label}")
     return "\n".join(lines)
+
+
+@as_latex.register(InteractionProperties)
+def _(obj: InteractionProperties) -> str:
+    lines: list[str] = []
+    if obj.l_magnitude is not None:
+        if obj.l_projection is None:
+            l_label = __render_latex_fraction(Fraction(obj.l_magnitude))
+        else:
+            l_label = as_latex(Spin(obj.l_magnitude, obj.l_projection))
+        lines.append(f"L = {l_label}")
+    if obj.s_magnitude is not None:
+        if obj.s_projection is None:
+            s_label = __render_latex_fraction(Fraction(obj.s_magnitude))
+        else:
+            s_label = as_latex(Spin(obj.s_magnitude, obj.s_projection))
+        lines.append(f"S = {s_label}")
+    if obj.parity_prefactor is not None:
+        label = __render_latex_fraction(Fraction(obj.parity_prefactor), plusminus=True)
+        lines.append(f"P = {label}")
+    return __render_latex_lines(lines)
 
 
 @as_string.register(EdgeSettings)
@@ -148,6 +276,29 @@ def _(settings: EdgeSettings | NodeSettings) -> str:
         output += "DOMAINS\n"
         output += "\n".join(domains)
     return output
+
+
+@as_latex.register(EdgeSettings)
+@as_latex.register(NodeSettings)
+def _(settings: EdgeSettings | NodeSettings) -> str:
+    lines: list[str] = []
+    if settings.rule_priorities:
+        lines.append(R"\text{RULES}")
+        rule_descriptions = (
+            f"{__render_rule(rule)} - {__get_priority(rule, settings.rule_priorities)}"
+            for rule in settings.conservation_rules
+        )
+        sorted_names = sorted(rule_descriptions, key=__extract_priority, reverse=True)
+        lines.extend(Rf"\text{{{__escape_latex_text(name)}}}" for name in sorted_names)
+    if settings.qn_domains:
+        lines.append(R"\text{DOMAINS}")
+        domains = sorted(
+            Rf"\text{{{__escape_latex_text(qn.__name__)}}} \in "
+            + __render_latex_domain(domain, key=qn.__name__)
+            for qn, domain in settings.qn_domains.items()
+        )
+        lines.extend(domains)
+    return __render_latex_lines(lines)
 
 
 def __get_priority(rule: Any, rule_priorities: dict[Any, int]) -> int | str:
@@ -200,9 +351,22 @@ def __render_domain(domain: list[Any], key: str) -> str:
     return "[" + ", ".join(domain_str) + "]"
 
 
+def __render_latex_domain(domain: list[Any], key: str) -> str:
+    domain = sorted(domain, key=lambda x: +9999 if x is None else x)
+    domain_str = [__render_latex_key_and_value(key, x) for x in domain]
+    return R"\left[" + ", ".join(domain_str) + R"\right]"
+
+
 @as_string.register(Particle)
 def _(particle: Particle) -> str:
     return particle.name
+
+
+@as_latex.register(Particle)
+def _(particle: Particle) -> str:
+    if particle.latex:
+        return particle.latex
+    return Rf"\text{{{__escape_latex_text(particle.name)}}}"
 
 
 @as_string.register(Spin)
@@ -212,11 +376,25 @@ def _spin_to_str(spin: Spin) -> str:
     return f"|{spin_magnitude},{spin_projection}⟩"
 
 
+@as_latex.register(Spin)
+def _spin_to_latex(spin: Spin) -> str:
+    spin_magnitude = __render_latex_fraction(spin.magnitude)
+    spin_projection = __render_latex_fraction(spin.projection, plusminus=True)
+    return Rf"\left|{spin_magnitude},{spin_projection}\right\rangle"
+
+
 @as_string.register(State)
 def _state_to_str(state: State) -> str:
     particle = state.particle.name
     spin_projection = _render_fraction(state.spin_projection, plusminus=True)
     return f"{particle}[{spin_projection}]"
+
+
+@as_latex.register(State)
+def _state_to_latex(state: State) -> str:
+    particle = as_latex(state.particle)
+    spin_projection = __render_latex_fraction(state.spin_projection, plusminus=True)
+    return Rf"{particle}\left[{spin_projection}\right]"
 
 
 @as_string.register(tuple)
@@ -229,6 +407,16 @@ def _(obj: tuple) -> str:
             spin = Spin(*obj)
             return _spin_to_str(spin)
     return "\n".join(map(as_string, obj))
+
+
+@as_latex.register(tuple)
+def _(obj: tuple) -> str:
+    if len(obj) == 2:
+        if isinstance(obj[0], Particle) and isinstance(obj[1], (Fraction, float, int)):
+            return _state_to_latex(State(*obj))
+        if all(isinstance(o, (Fraction, float, int)) for o in obj):
+            return _spin_to_latex(Spin(*obj))
+    return __render_latex_lines([as_latex(item) for item in obj])
 
 
 def get_particle_graphs(

--- a/src/qrules/io/_mermaid.py
+++ b/src/qrules/io/_mermaid.py
@@ -29,6 +29,10 @@ _LABEL_ESCAPES: dict[str, str] = {
     '"': r"\"",
     "\n": "<br/>",
 }
+_LATEX_LABEL_TABLE = str.maketrans({
+    '"': r"\"",
+    "\n": " ",
+})
 
 _NODE_LABEL_TABLE = str.maketrans(_LABEL_ESCAPES)
 _EDGE_LABEL_TABLE = str.maketrans({**_LABEL_ESCAPES, "|": r"\|"})
@@ -85,6 +89,7 @@ class MermaidPrinter:
     figure_style: dict[str, Any] = attrs.field(converter=_to_style_dict, default=None)
     edge_style: dict[str, Any] = attrs.field(converter=_to_style_dict, default=None)
     node_style: dict[str, Any] = attrs.field(converter=_to_style_dict, default=None)
+    latex: bool = False
 
     def __call__(self, obj: Any) -> str:
         lines = ["flowchart LR"]
@@ -160,6 +165,7 @@ class MermaidPrinter:
             )
         else:
             render_node = self.render_node
+        render_label = _labels.as_latex if self.latex else _labels.as_string
 
         folded_initial_edge_id: int | None = None
         if len(topology.incoming_edge_ids) == 1 and not render_node:
@@ -173,7 +179,9 @@ class MermaidPrinter:
                 render = self.render_initial_state_id
             else:
                 render = self.render_final_state_id
-            label = _labels.create_edge_label(rendered_graph, edge_id, render)
+            label = _labels.create_edge_label(
+                rendered_graph, edge_id, render, render_label=render_label
+            )
             if edge_id == folded_initial_edge_id:
                 node_id = topology.edges[edge_id].ending_node_id
                 add_node(f"{prefix}N{node_id}", label)
@@ -191,11 +199,11 @@ class MermaidPrinter:
                 node_id,
                 settings,
             ) in rendered_graph.solving_settings.interactions.items():
-                add_node(f"{prefix}N{node_id}", _labels.as_string(settings))
+                add_node(f"{prefix}N{node_id}", render_label(settings))
 
         if isinstance(rendered_graph, Transition) and render_node:
             for node_id, node_prop in rendered_graph.interactions.items():
-                add_node(f"{prefix}N{node_id}", _labels.as_string(node_prop))
+                add_node(f"{prefix}N{node_id}", render_label(node_prop))
 
         edge_style_lines: list[str] = []
         edge_index = 0
@@ -209,7 +217,10 @@ class MermaidPrinter:
                 edge_lines.append(self._create_mermaid_edge(from_node, to_node))
             else:
                 label = _labels.create_edge_label(
-                    rendered_graph, edge_id, self.render_resonance_id
+                    rendered_graph,
+                    edge_id,
+                    self.render_resonance_id,
+                    render_label=render_label,
                 )
                 edge_lines.append(self._create_mermaid_edge(from_node, to_node, label))
             if self.edge_style:
@@ -294,6 +305,8 @@ class MermaidPrinter:
                 escaped_label = self._escape_label(label)
                 return f'    {from_node} --"{escaped_label}"--- {to_node}'
             escaped_label = self._escape_label(label, for_edge=True)
+            if self.latex:
+                return f'    {from_node} ---|"{escaped_label}"| {to_node}'
             if any(char in escaped_label for char in "[]()"):
                 escaped_label = f'"{escaped_label}"'
             return f"    {from_node} ---|{escaped_label}| {to_node}"
@@ -308,7 +321,10 @@ class MermaidPrinter:
             normalized = f"n_{normalized}"
         return normalized
 
-    @staticmethod
-    def _escape_label(label: str, *, for_edge: bool = False) -> str:
+    def _escape_label(self, label: str, *, for_edge: bool = False) -> str:
+        if self.latex:
+            escaped_label = str(label).strip().translate(_LATEX_LABEL_TABLE)
+            escaped_label = escaped_label.replace(2 * "\\", 3 * "\\")
+            return f"$${escaped_label}$$"
         table = _EDGE_LABEL_TABLE if for_edge else _NODE_LABEL_TABLE
         return str(label).strip().translate(table)

--- a/src/qrules/io/_mermaid.py
+++ b/src/qrules/io/_mermaid.py
@@ -29,11 +29,6 @@ _LABEL_ESCAPES: dict[str, str] = {
     '"': r"\"",
     "\n": "<br/>",
 }
-_LATEX_LABEL_TABLE = str.maketrans({
-    '"': r"\"",
-    "\n": " ",
-})
-
 _NODE_LABEL_TABLE = str.maketrans(_LABEL_ESCAPES)
 _EDGE_LABEL_TABLE = str.maketrans({**_LABEL_ESCAPES, "|": r"\|"})
 
@@ -347,8 +342,26 @@ class MermaidPrinter:
 
     def _escape_label(self, label: str, *, for_edge: bool = False) -> str:
         if self.latex:
-            escaped_label = str(label).strip().translate(_LATEX_LABEL_TABLE)
-            escaped_label = escaped_label.replace(2 * "\\", 3 * "\\")
+            escaped_label = _escape_latex_label(label)
             return f"$${escaped_label}$$"
         table = _EDGE_LABEL_TABLE if for_edge else _NODE_LABEL_TABLE
         return str(label).strip().translate(table)
+
+
+def _escape_latex_label(label: str) -> str:
+    R"""Escape a KaTeX label so that it survives Mermaid's string lexer.
+
+    Within a quoted label, Mermaid reads ``\\`` and ``\"`` as escape sequences and
+    passes any other backslash sequence through untouched. A backslash therefore has to
+    be doubled only where it precedes another backslash or a quote. Escaping the quotes
+    first and rewriting each remaining ``\\`` pair with three backslashes produces
+    exactly that: the KaTeX row separator ``\\`` arrives as two backslashes, and an
+    accent such as ``\"`` arrives with its quote intact.
+
+    >>> print(_escape_latex_label(R"L = 0 \\ S = 1"))
+    L = 0 \\\ S = 1
+    >>> print(_escape_latex_label(R"\"o"))
+    \\\"o
+    """
+    escaped_label = str(label).strip().replace("\n", " ").replace('"', R"\"")
+    return escaped_label.replace(2 * "\\", 3 * "\\")

--- a/src/qrules/io/_mermaid.py
+++ b/src/qrules/io/_mermaid.py
@@ -89,7 +89,7 @@ class MermaidPrinter:
     figure_style: dict[str, Any] = attrs.field(converter=_to_style_dict, default=None)
     edge_style: dict[str, Any] = attrs.field(converter=_to_style_dict, default=None)
     node_style: dict[str, Any] = attrs.field(converter=_to_style_dict, default=None)
-    latex: bool = False
+    latex: bool = True
 
     def __call__(self, obj: Any) -> str:
         lines = ["flowchart LR"]

--- a/src/qrules/io/_mermaid.py
+++ b/src/qrules/io/_mermaid.py
@@ -342,13 +342,13 @@ class MermaidPrinter:
 
     def _escape_label(self, label: str, *, for_edge: bool = False) -> str:
         if self.latex:
-            escaped_label = _escape_latex_label(label)
+            escaped_label = _escape_latex_for_mermaid(label)
             return f"$${escaped_label}$$"
         table = _EDGE_LABEL_TABLE if for_edge else _NODE_LABEL_TABLE
         return str(label).strip().translate(table)
 
 
-def _escape_latex_label(label: str) -> str:
+def _escape_latex_for_mermaid(label: str) -> str:
     R"""Escape a KaTeX label so that it survives Mermaid's string lexer.
 
     Within a quoted label, Mermaid reads ``\\`` and ``\"`` as escape sequences and
@@ -358,9 +358,9 @@ def _escape_latex_label(label: str) -> str:
     exactly that: the KaTeX row separator ``\\`` arrives as two backslashes, and an
     accent such as ``\"`` arrives with its quote intact.
 
-    >>> print(_escape_latex_label(R"L = 0 \\ S = 1"))
+    >>> print(_escape_latex_for_mermaid(R"L = 0 \\ S = 1"))
     L = 0 \\\ S = 1
-    >>> print(_escape_latex_label(R"\"o"))
+    >>> print(_escape_latex_for_mermaid(R"\"o"))
     \\\"o
     """
     escaped_label = str(label).strip().replace("\n", " ").replace('"', R"\"")

--- a/src/qrules/io/_mermaid.py
+++ b/src/qrules/io/_mermaid.py
@@ -277,6 +277,8 @@ class MermaidPrinter:
             style_key = self._normalize_style_key(key, target)
             if style_key is None:
                 continue
+            if style_key == "font-size" and isinstance(value, (int, float)):
+                value = f"{value}px"
             parts.append(f"{style_key}:{value}")
         return ",".join(parts)
 
@@ -293,6 +295,9 @@ class MermaidPrinter:
 
     def _create_mermaid_node(self, node_id: str, label: str = "") -> str:
         if label:
+            if self.latex:
+                style = {**self.figure_style, **self.node_style}
+                label = self._apply_latex_color(label, style, target="node")
             escaped_label = self._escape_label(label)
             return f'    {node_id}["{escaped_label}"]'
         return f'    {node_id}@{{ shape: text, label: " " }}'
@@ -301,6 +306,8 @@ class MermaidPrinter:
         self, from_node: str, to_node: str, label: str = ""
     ) -> str:
         if label:
+            if self.latex:
+                label = self._apply_latex_color(label, self.edge_style, target="edge")
             if "|" in label:
                 escaped_label = self._escape_label(label)
                 return f'    {from_node} --"{escaped_label}"--- {to_node}'
@@ -320,6 +327,23 @@ class MermaidPrinter:
         if normalized[0].isdigit():
             normalized = f"n_{normalized}"
         return normalized
+
+    @classmethod
+    def _apply_latex_color(
+        cls, label: str, style: dict[str, Any], *, target: str
+    ) -> str:
+        color = next(
+            (
+                value
+                for key, value in reversed(style.items())
+                if value is not None
+                and cls._normalize_style_key(key, target) == "color"
+            ),
+            None,
+        )
+        if color is None:
+            return label
+        return Rf"\textcolor{{{color}}}{{{label}}}"
 
     def _escape_label(self, label: str, *, for_edge: bool = False) -> str:
         if self.latex:

--- a/tests/unit/io/test_labels.py
+++ b/tests/unit/io/test_labels.py
@@ -27,6 +27,18 @@ def test_as_latex_is_extensible():
     assert as_latex(CustomLabel()) == R"\alpha"
 
 
+def test_label_renderer_dispatch_is_independent():
+    class CustomLabel:
+        pass
+
+    as_string.register(CustomLabel, lambda _: "plain")
+    as_latex.register(CustomLabel, lambda _: R"\mathrm{latex}")
+
+    label = CustomLabel()
+    assert as_string(label) == "plain"
+    assert as_latex(label) == R"\mathrm{latex}"
+
+
 def test_as_latex_fallback(caplog):
     class UnsupportedLabel:
         def __str__(self) -> str:
@@ -43,6 +55,13 @@ def test_as_latex_particle_and_state(particle_database: ParticleCollection):
     expected_state = R"J/\psi(1S)\left[-\frac{1}{2}\right]"
     assert as_latex(State(particle, Fraction(-1, 2))) == expected_state
     assert as_latex((particle, Fraction(-1, 2))) == expected_state
+
+    particle_with_custom_latex = attrs.evolve(
+        particle,
+        name="this_name_is_not_rendered",
+        latex=R"\mathrm{x}_{100\%}",
+    )
+    assert as_latex(particle_with_custom_latex) == R"\mathrm{x}_{100\%}"
 
     particle_without_latex = attrs.evolve(particle, name="custom_name", latex=None)
     assert as_latex(particle_without_latex) == R"\text{custom\_name}"

--- a/tests/unit/io/test_labels.py
+++ b/tests/unit/io/test_labels.py
@@ -1,16 +1,135 @@
+import logging
 from fractions import Fraction
 from textwrap import dedent
 
+import attrs
+
 import qrules
 from qrules.io._labels import (
+    as_latex,
     as_string,
     collapse_graphs,
+    create_edge_label,
     get_particle_graphs,
     strip_projections,
 )
 from qrules.particle import Particle, ParticleCollection
+from qrules.quantum_numbers import InteractionProperties
 from qrules.solving import QNProblemSet, QNResult
-from qrules.transition import ProblemSet, ReactionInfo
+from qrules.transition import ProblemSet, ReactionInfo, State
+
+
+def test_as_latex_is_extensible():
+    class CustomLabel:
+        pass
+
+    as_latex.register(CustomLabel, lambda _: R"\alpha")
+    assert as_latex(CustomLabel()) == R"\alpha"
+
+
+def test_as_latex_fallback(caplog):
+    class UnsupportedLabel:
+        def __str__(self) -> str:
+            return "unsupported"
+
+    with caplog.at_level(logging.WARNING):
+        assert as_latex(UnsupportedLabel()) == "unsupported"
+    assert "No LaTeX label renderer implemented type UnsupportedLabel" in caplog.text
+
+
+def test_as_latex_particle_and_state(particle_database: ParticleCollection):
+    particle = particle_database["J/psi(1S)"]
+    assert as_latex(particle) == R"J/\psi(1S)"
+    expected_state = R"J/\psi(1S)\left[-\frac{1}{2}\right]"
+    assert as_latex(State(particle, Fraction(-1, 2))) == expected_state
+    assert as_latex((particle, Fraction(-1, 2))) == expected_state
+
+    particle_without_latex = attrs.evolve(particle, name="custom_name", latex=None)
+    assert as_latex(particle_without_latex) == R"\text{custom\_name}"
+
+    special_name = R"\{}$&#_%~^"
+    particle_without_latex = attrs.evolve(particle, name=special_name, latex=None)
+    assert as_latex(particle_without_latex) == (
+        R"\text{\textbackslash{}\{\}\$\&\#\_\%"
+        R"\textasciitilde{}\textasciicircum{}}"
+    )
+
+
+def test_as_latex_spin_and_interaction():
+    assert as_latex((Fraction(1, 2), Fraction(1, 2))) == (
+        R"\left|\frac{1}{2},+\frac{1}{2}\right\rangle"
+    )
+    interaction = InteractionProperties(
+        l_magnitude=1,
+        l_projection=0,
+        s_magnitude=Fraction(1, 2),
+        parity_prefactor=1,
+    )
+    src = as_latex(interaction)
+    assert src.startswith(R"\begin{gathered}")
+    assert R"L = \left|1,0\right\rangle" in src
+    assert R"S = \frac{1}{2}" in src
+    assert "P = +1" in src
+
+    assert not as_latex(InteractionProperties())
+    assert as_latex(InteractionProperties(l_magnitude=1)) == "L = 1"
+    assert (
+        as_latex(
+            InteractionProperties(
+                s_magnitude=Fraction(1, 2), s_projection=Fraction(-1, 2)
+            )
+        )
+        == R"S = \left|\frac{1}{2},-\frac{1}{2}\right\rangle"
+    )
+
+
+def test_as_latex_dict_and_basic_values():
+    assert as_latex(1) == "1"
+    assert as_latex(1.5) == "1.5"
+    assert as_latex(R"\alpha") == R"\alpha"
+    src = as_latex({"spin_magnitude": Fraction(1, 2), "parity": 1})
+    assert R"\text{spin\_magnitude} = \frac{1}{2}" in src
+    assert R"\text{parity} = +1" in src
+    assert as_latex(Fraction(-1, 2)) == R"-\frac{1}{2}"
+    assert as_latex(None) == R"\mathrm{None}"
+    assert not as_latex({})
+    assert as_latex({"pid": 1}) == R"\text{pid} = 1"
+
+
+def test_as_latex_collapsed_particle_tuple(particle_database: ParticleCollection):
+    particles = (
+        particle_database["f(0)(980)"],
+        particle_database["f(0)(1500)"],
+    )
+    assert as_latex(particles) == (
+        R"\begin{gathered} f_{0}(980) \\ f_{0}(1500) \end{gathered}"
+    )
+
+
+def test_create_edge_label_accepts_renderer(reaction: ReactionInfo):
+    transition = reaction.transitions[0]
+    edge_id = next(iter(transition.topology.incoming_edge_ids))
+    state = transition.states[edge_id]
+
+    plain_label = create_edge_label(transition, edge_id, render_edge_id=False)
+    latex_label = create_edge_label(
+        transition,
+        edge_id,
+        render_edge_id=False,
+        render_label=as_latex,
+    )
+
+    assert plain_label.startswith(state.particle.name)
+    assert state.particle.latex is not None
+    assert latex_label.startswith(state.particle.latex)
+
+    multiline_label = create_edge_label(
+        transition,
+        edge_id,
+        render_edge_id=True,
+        render_label=lambda _: "first\nsecond",
+    )
+    assert multiline_label == f"{edge_id}:\nfirst\nsecond"
 
 
 def test_as_string_dict(
@@ -113,6 +232,20 @@ def test_as_string_dict(
         "width = 0.15",
     }
     assert lines == expected_lines
+
+    latex = as_latex(intermediate_setting)
+    assert R"\text{RULES}" in latex
+    assert R"\text{spin\_validity - 62}" in latex
+    assert R"\text{DOMAINS}" in latex
+    assert R"\text{spin\_magnitude} \in \left[\frac{1}{2}\right]" in latex
+
+    latex = as_latex(node_setting)
+    assert R"\text{ChargeConservation - 100}" in latex
+    assert R"\text{l\_magnitude} \in \left[0, 1\right]" in latex
+
+    latex = as_latex(intermediate_state)
+    assert R"\text{spin\_magnitude} = \frac{1}{2}" in latex
+    assert R"\text{parity} = +1" in latex
 
 
 def test_as_string_spin_tuple(particle_database: ParticleCollection):

--- a/tests/unit/io/test_mermaid.py
+++ b/tests/unit/io/test_mermaid.py
@@ -276,6 +276,19 @@ def test_mermaid_latex_labels_are_wrapped_and_escaped():
     )
 
 
+def test_mermaid_latex_label_colors_are_applied():
+    printer = MermaidPrinter(
+        latex=True,
+        edge_style={"color": "red", "fontcolor": "blue"},
+        node_style={"fontcolor": "gray"},
+    )
+    node_line = printer._create_mermaid_node("A", R"\alpha")
+    edge_line = printer._create_mermaid_edge("A", "B", R"\gamma")
+
+    assert node_line == R'    A["$$\textcolor{gray}{\alpha}$$"]'
+    assert edge_line == R'    A ---|"$$\textcolor{blue}{\gamma}$$"| B'
+
+
 def test_mermaid_edge_labels_with_state_brackets_are_quoted():
     edge_line = MermaidPrinter(latex=False)._create_mermaid_edge(
         "A", "B", "f(2)(2340)[-2]"

--- a/tests/unit/io/test_mermaid.py
+++ b/tests/unit/io/test_mermaid.py
@@ -36,6 +36,7 @@ def test_asmermaid_api():
     assert src.startswith("flowchart LR\n")
     assert "    n_0" in src
     assert " --- " in src
+    assert "$$" not in src
 
 
 def test_asmermaid_markdown_fence():
@@ -43,6 +44,52 @@ def test_asmermaid_markdown_fence():
     src = io.asmermaid(topology, markdown=True)
     assert src.startswith("```mermaid\nflowchart LR\n")
     assert src.endswith("\n```\n")
+
+
+def test_asmermaid_latex_markdown(reaction: ReactionInfo):
+    src = io.asmermaid(reaction.transitions[0], latex=True, markdown=True)
+    assert src.startswith("```mermaid\nflowchart LR\n")
+    assert R"$$J/\psi(1S)" in src
+    assert R"J/\\psi(1S)" not in src
+    assert src.endswith("\n```\n")
+
+
+def test_asmermaid_latex_reaction(reaction: ReactionInfo):
+    src = io.asmermaid(
+        reaction.transitions[0],
+        render_node=True,
+        render_resonance_id=True,
+        latex=True,
+    )
+    assert src.startswith("flowchart LR\n")
+    assert not src.startswith("```mermaid")
+    assert R"J/\psi(1S)\left[" in src
+    assert R"f_{0}(980)\left[" in src
+    assert "P = +1" in src
+    assert "<br/>" not in src
+    if reaction.formalism == "canonical-helicity":
+        assert R"$$\begin{gathered} L =" in src
+
+    labeled_lines = [
+        line
+        for line in src.splitlines()
+        if '["' in line or '---|"' in line or '--"' in line
+    ]
+    assert labeled_lines
+    assert all(line.count("$$") == 2 for line in labeled_lines)
+
+
+def test_asmermaid_latex_collapsed_graph(reaction: ReactionInfo):
+    src = io.asmermaid(reaction, collapse_graphs=True, latex=True)
+    assert R"$$\begin{gathered} f_{0}(980)" in src
+    assert R"\\\ f_{0}(1500) \end{gathered}$$" in src
+
+
+def test_asmermaid_latex_strip_spin(reaction: ReactionInfo):
+    src = io.asmermaid(reaction, strip_spin=True, latex=True)
+    assert R"J/\psi(1S)$$" in src
+    assert R"\gamma$$" in src
+    assert R"\left[" not in src
 
 
 def test_asmermaid_accepts_style_parameters():
@@ -141,12 +188,27 @@ def test_asmermaid_qn_problem_set(qn_problem_and_result: tuple[QNProblemSet, QNR
     assert "DOMAINS" in src
 
 
+def test_asmermaid_latex_qn_problem_set(
+    qn_problem_and_result: tuple[QNProblemSet, QNResult],
+):
+    qn_problem_set, _ = qn_problem_and_result
+    src = io.asmermaid(qn_problem_set, render_node=True, latex=True)
+    assert R"$$\begin{gathered} \text{RULES}" in src
+    assert R"\text{DOMAINS}" in src
+    assert R"\text{spin\_magnitude} \in" in src
+    assert "<br/>" not in src
+
+
 def test_asmermaid_qn_result(qn_problem_and_result: tuple[QNProblemSet, QNResult]):
     _, qn_result = qn_problem_and_result
     src = io.asmermaid(qn_result, render_node=True)
     assert src.startswith("flowchart LR\n")
     assert " --- " in src
     assert "parity_prefactor =" in src
+
+    src = io.asmermaid(qn_result, render_node=True, latex=True)
+    assert R"$$\begin{gathered}" in src
+    assert R"\text{parity\_prefactor} = +1" in src
 
 
 @pytest.mark.parametrize(
@@ -190,6 +252,27 @@ def test_mermaid_labels_are_escaped():
     )
     assert 'value with \\"quotes\\" and<br/>line break' in node_line
     assert 'value with \\"quotes\\" and<br/>line break' in edge_line
+
+
+def test_mermaid_latex_labels_are_wrapped_and_escaped():
+    printer = MermaidPrinter(latex=True)
+    node_line = printer._create_mermaid_node("A", '\\alpha + "quoted"\n+ \\beta')
+    edge_line = printer._create_mermaid_edge("A", "B", R"\gamma")
+    ket_edge_line = printer._create_mermaid_edge(
+        "A", "B", R"\left|\frac{1}{2},+\frac{1}{2}\right\rangle"
+    )
+    multiline_node_line = printer._create_mermaid_node(
+        "A", R"\begin{gathered} L = 0 \\ S = 1 \end{gathered}"
+    )
+
+    assert node_line == R'    A["$$\alpha + \"quoted\" + \beta$$"]'
+    assert edge_line == R'    A ---|"$$\gamma$$"| B'
+    assert ket_edge_line == (
+        R'    A --"$$\left|\frac{1}{2},+\frac{1}{2}\right\rangle$$"--- B'
+    )
+    assert multiline_node_line == (
+        R'    A["$$\begin{gathered} L = 0 \\\ S = 1 \end{gathered}$$"]'
+    )
 
 
 def test_mermaid_edge_labels_with_state_brackets_are_quoted():

--- a/tests/unit/io/test_mermaid.py
+++ b/tests/unit/io/test_mermaid.py
@@ -39,6 +39,11 @@ def test_asmermaid_api():
     assert "$$" in src
 
 
+def test_mermaid_latex_default_matches_public_api():
+    topology = create_n_body_topology(3, 4)
+    assert MermaidPrinter()(topology) == io.asmermaid(topology)
+
+
 def test_asmermaid_markdown_fence():
     topology = create_n_body_topology(3, 4)
     src = io.asmermaid(topology, markdown=True)
@@ -142,6 +147,14 @@ def test_asmermaid_reaction_with_node_labels(reaction: ReactionInfo):
     assert "f(0)(980)[0]" in src
     assert "P=+1" in src
     assert "    A --- N0" in src
+
+
+def test_asmermaid_latex_can_be_disabled(reaction: ReactionInfo):
+    src = io.asmermaid(reaction.transitions[0], render_node=True, latex=False)
+    assert "$$" not in src
+    assert R"\text" not in src
+    assert R"\frac" not in src
+    assert R"\left" not in src
 
 
 def test_asmermaid_keeps_multiple_initial_states_separate():
@@ -276,9 +289,25 @@ def test_mermaid_latex_labels_are_wrapped_and_escaped():
     )
 
 
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        (R"\alpha", R"$$\alpha$$"),
+        (R"L = 0 \\ S = 1", R"$$L = 0 \\\ S = 1$$"),
+        ('value with "quotes"', R"$$value with \"quotes\"$$"),
+        ("first\nsecond", "$$first second$$"),
+        (R"\$100", R"$$\$100$$"),
+        (R"\{x\}", R"$$\{x\}$$"),
+    ],
+)
+def test_mermaid_latex_label_transport(label: str, expected: str):
+    assert MermaidPrinter(latex=True)._escape_label(label) == expected
+
+
 def test_mermaid_latex_label_colors_are_applied():
     printer = MermaidPrinter(
         latex=True,
+        figure_style={"fontcolor": "black"},
         edge_style={"color": "red", "fontcolor": "blue"},
         node_style={"fontcolor": "gray"},
     )
@@ -287,6 +316,28 @@ def test_mermaid_latex_label_colors_are_applied():
 
     assert node_line == R'    A["$$\textcolor{gray}{\alpha}$$"]'
     assert edge_line == R'    A ---|"$$\textcolor{blue}{\gamma}$$"| B'
+
+
+@pytest.mark.parametrize("color", ["red", "gray", "#123456"])
+def test_mermaid_latex_supported_label_colors(color: str):
+    printer = MermaidPrinter(latex=True, node_style={"fontcolor": color})
+    assert printer._create_mermaid_node("A", R"\alpha") == (
+        Rf'    A["$$\textcolor{{{color}}}{{\alpha}}$$"]'
+    )
+
+
+@pytest.mark.parametrize(
+    ("font_size", "expected"),
+    [
+        (25, "font-size:25px"),
+        (12.5, "font-size:12.5px"),
+        ("12pt", "font-size:12pt"),
+        (None, ""),
+    ],
+)
+def test_mermaid_font_size_formatting(font_size: object, expected: str):
+    printer = MermaidPrinter()
+    assert printer._format_style_dict({"fontsize": font_size}) == expected
 
 
 def test_mermaid_edge_labels_with_state_brackets_are_quoted():

--- a/tests/unit/io/test_mermaid.py
+++ b/tests/unit/io/test_mermaid.py
@@ -298,6 +298,7 @@ def test_mermaid_latex_labels_are_wrapped_and_escaped():
         ("first\nsecond", "$$first second$$"),
         (R"\$100", R"$$\$100$$"),
         (R"\{x\}", R"$$\{x\}$$"),
+        (R"\"o", R"$$\\\"o$$"),
     ],
 )
 def test_mermaid_latex_label_transport(label: str, expected: str):

--- a/tests/unit/io/test_mermaid.py
+++ b/tests/unit/io/test_mermaid.py
@@ -36,7 +36,7 @@ def test_asmermaid_api():
     assert src.startswith("flowchart LR\n")
     assert "    n_0" in src
     assert " --- " in src
-    assert "$$" not in src
+    assert "$$" in src
 
 
 def test_asmermaid_markdown_fence():
@@ -97,12 +97,12 @@ def test_asmermaid_accepts_style_parameters():
     src = io.asmermaid(
         topology,
         figure_style={"bgcolor": "white"},
-        edge_style={"color": "blue"},
+        edge_style={"color": "blue", "fontsize": 25},
         node_style={"fill": "green"},
     )
     assert src.startswith("flowchart LR\n")
     assert "style n_0 fill:green" in src
-    assert "linkStyle 0 stroke:blue" in src
+    assert "linkStyle 0 stroke:blue,font-size:25px" in src
 
 
 def test_write_mermaid_file(tmp_path):
@@ -116,7 +116,7 @@ def test_write_mermaid_file(tmp_path):
 
 def test_asmermaid_reaction(reaction: ReactionInfo):
     for transition in reaction.transitions:
-        src = io.asmermaid(transition)
+        src = io.asmermaid(transition, latex=False)
         assert src.startswith("flowchart LR\n")
         assert " --- " in src
         initial_state_id = next(iter(transition.topology.incoming_edge_ids))
@@ -124,19 +124,19 @@ def test_asmermaid_reaction(reaction: ReactionInfo):
         initial_state = transition.states[initial_state_id]
         assert f'N{initial_node_id}["{initial_state.particle.name}' in src
         assert f"    A --- N{initial_node_id}" not in src
-    src = io.asmermaid(reaction)
+    src = io.asmermaid(reaction, latex=False)
     assert src.startswith("flowchart LR\n")
     assert " --- " in src
-    src = io.asmermaid(reaction, strip_spin=True)
+    src = io.asmermaid(reaction, strip_spin=True, latex=False)
     assert src.startswith("flowchart LR\n")
     assert " --- " in src
-    src = io.asmermaid(reaction, collapse_graphs=True)
+    src = io.asmermaid(reaction, collapse_graphs=True, latex=False)
     assert src.startswith("flowchart LR\n")
     assert " --- " in src
 
 
 def test_asmermaid_reaction_with_node_labels(reaction: ReactionInfo):
-    src = io.asmermaid(reaction.transitions[0], render_node=True)
+    src = io.asmermaid(reaction.transitions[0], render_node=True, latex=False)
     assert src.startswith("flowchart LR\n")
     assert "gamma[-1]" in src
     assert "f(0)(980)[0]" in src
@@ -158,6 +158,7 @@ def test_asmermaid_edge_id_options():
         render_final_state_id=False,
         render_resonance_id=True,
         render_node=False,
+        latex=False,
     )
     assert src.startswith("flowchart LR\n")
     assert any(label in src for label in (" ---|5| ", " ---|6| ", " ---|7| "))
@@ -201,7 +202,7 @@ def test_asmermaid_latex_qn_problem_set(
 
 def test_asmermaid_qn_result(qn_problem_and_result: tuple[QNProblemSet, QNResult]):
     _, qn_result = qn_problem_and_result
-    src = io.asmermaid(qn_result, render_node=True)
+    src = io.asmermaid(qn_result, render_node=True, latex=False)
     assert src.startswith("flowchart LR\n")
     assert " --- " in src
     assert "parity_prefactor =" in src
@@ -245,7 +246,7 @@ def test_asmermaid_problemset(formalism: SpinFormalism):
 
 
 def test_mermaid_labels_are_escaped():
-    printer = MermaidPrinter()
+    printer = MermaidPrinter(latex=False)
     node_line = printer._create_mermaid_node("A", 'value with "quotes" and\nline break')
     edge_line = printer._create_mermaid_edge(
         "A", "B", 'value with "quotes" and\nline break'
@@ -276,12 +277,14 @@ def test_mermaid_latex_labels_are_wrapped_and_escaped():
 
 
 def test_mermaid_edge_labels_with_state_brackets_are_quoted():
-    edge_line = MermaidPrinter()._create_mermaid_edge("A", "B", "f(2)(2340)[-2]")
+    edge_line = MermaidPrinter(latex=False)._create_mermaid_edge(
+        "A", "B", "f(2)(2340)[-2]"
+    )
     assert edge_line == '    A ---|"f(2)(2340)[-2]"| B'
 
 
 def test_mermaid_edge_labels_with_ket_vectors_are_quoted():
-    edge_line = MermaidPrinter()._create_mermaid_edge("A", "B", "|1,-1⟩")
+    edge_line = MermaidPrinter(latex=False)._create_mermaid_edge("A", "B", "|1,-1⟩")
     assert edge_line == '    A --"|1,-1⟩"--- B'
 
 


### PR DESCRIPTION
Closes #349

## ✨ New features

- New `as_latex()` renderer alongside `as_string()` in `qrules.io._labels`, a `functools.singledispatch` function that mirrors `as_string()` but emits LaTeX source. Implementations are registered for `Particle`, `State`, `Spin`, `InteractionProperties`, `EdgeSettings`, `NodeSettings`, `Fraction`, `dict`, `tuple` and `None`, and downstream code can register its own types. Particle labels use `.Particle.latex` where available and fall back to an escaped `\text{...}` of the particle name.
- `asmermaid()` takes a new `latex` argument that switches label rendering between LaTeX math and the previous plain-text labels. Mermaid labels are emitted as `$$...$$` so that Mermaid's KaTeX renderer picks them up, and multi-line labels become a `gathered` environment instead of `<br/>` breaks.

## ⚙️ Enhancements

- Label colors set through `figure_style`, `node_style` and `edge_style` are now carried into LaTeX labels with `\textcolor`, since KaTeX ignores the surrounding Mermaid CSS color.
- A numeric `font-size` in a style dictionary is now emitted with a `px` unit, so that Mermaid actually applies it.

## ❗ Behavioral changes

- Mermaid output renders its edge and node labels as LaTeX math by default (`latex=True`). Existing calls to `asmermaid()` therefore produce different source than before. Pass `latex=False` to get the previous plain-text labels.

## 🖱️ Developer experience

- Recommend the Mermaid Chart extension in the workspace extension recommendations, so that Mermaid sources can be previewed in VS Code.

## 📝 Documentation

- The visualization notebook shows how to switch LaTeX rendering off, and renders its Mermaid diagrams full width.
- Agent configuration files are excluded from the Sphinx toctree and the fullscreen button is removed from the website.

## Squash commit messages

```text
* BEHAVIOR: enable LaTeX label rendering by default
* DOC: document how to disable LaTeX rendering
* DOC: render Mermaid diagrams full width
* DX: recommend VS Code Mermaid extension
* ENH: apply label color and font size to LaTeX labels
* FEAT: add `as_latex()` label renderer
* FEAT: add `latex` argument to `asmermaid()`
* MAINT: exclude agent configurations from the toctree
```