### PR TITLE
BREAK: rename reaction_mode to solving_mode

### DIFF
--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -236,7 +236,7 @@ class StateTransitionManager:
         | None = None,
         formalism: SpinFormalism = "helicity",
         topology_building: str = "isobar",
-        solving_mode: SolvingMode = SolvingMode.FAST,
+        solving_mode: SolvingMode = SolvingMode.FULL,
         reload_pdg: bool = False,
         mass_conservation_factor: float | None = 3.0,
         max_angular_momentum: int = 1,
@@ -259,7 +259,8 @@ class StateTransitionManager:
         self.__particles = ParticleCollection()
         if particle_db is not None:
             self.__particles = particle_db
-        self.reaction_mode = str(solving_mode)
+        self.solving_mode = solving_mode
+        """Whether to search for all solutions or stop at the strongest interaction."""
         self.initial_state = list(map(as_state_definition, initial_state))
         self.final_state = list(map(as_state_definition, final_state))
         self.interaction_type_settings = interaction_type_settings
@@ -633,7 +634,7 @@ class StateTransitionManager:
                     qn_solution = self._solve(problem)
                     qn_results[strength].append(qn_solution)
                     progress_bar.update()
-            if self.reaction_mode == SolvingMode.FAST and any(
+            if self.solving_mode == SolvingMode.FAST and any(
                 qn_result.solutions for _, qn_result in qn_results[strength]
             ):
                 break

--- a/src/qrules/transition.py
+++ b/src/qrules/transition.py
@@ -467,7 +467,7 @@ class StateTransitionManager:
         for node_id in topology.nodes:
             interaction_types: list[InteractionType] = []
             out_edge_ids = topology.get_edge_ids_outgoing_from_node(node_id)
-            in_edge_ids = topology.get_edge_ids_outgoing_from_node(node_id)
+            in_edge_ids = topology.get_edge_ids_ingoing_to_node(node_id)
             in_states = [
                 initial_facts.states[edge_id]
                 for edge_id in [x for x in in_edge_ids if x in initial_state_edges]
@@ -633,7 +633,9 @@ class StateTransitionManager:
                     qn_solution = self._solve(problem)
                     qn_results[strength].append(qn_solution)
                     progress_bar.update()
-            if qn_results[strength] and self.reaction_mode == SolvingMode.FAST:
+            if self.reaction_mode == SolvingMode.FAST and any(
+                qn_result.solutions for _, qn_result in qn_results[strength]
+            ):
                 break
         progress_bar.close()
         return qn_results

--- a/tests/unit/test_transition.py
+++ b/tests/unit/test_transition.py
@@ -123,6 +123,20 @@ class TestStateTransitionManager:
         ):
             stm.set_allowed_intermediate_particles(particle_name)
 
+    @pytest.mark.parametrize(
+        ("initial_state", "expected_strengths"),
+        [
+            (["gamma"], [0.0001, 1.0, 60.0]),
+            (["nu(e)"], [1e-08, 0.0001, 0.006]),
+        ],
+    )
+    def test_initial_state_restricts_interaction_types(
+        self, initial_state: list[str], expected_strengths: list[float]
+    ):
+        stm = StateTransitionManager(initial_state, final_state=["pi0", "pi0", "pi0"])
+        problem_sets = stm.create_problem_sets()
+        assert sorted(problem_sets) == expected_strengths
+
     def test_regex_pattern(self):
         stm = StateTransitionManager(
             initial_state=["Lambda(c)+"],

--- a/tests/unit/test_transition.py
+++ b/tests/unit/test_transition.py
@@ -22,7 +22,7 @@ from qrules.topology import (  # ruff: ignore[unused-import]
     MutableTransition,
     Topology,
 )
-from qrules.transition import ReactionInfo, State, StateTransitionManager
+from qrules.transition import ReactionInfo, SolvingMode, State, StateTransitionManager
 
 NAMESPACE_WITH_FRACTIONS = globals()
 NAMESPACE_WITH_FRACTIONS["Fraction"] = Fraction
@@ -136,6 +136,19 @@ class TestStateTransitionManager:
         stm = StateTransitionManager(initial_state, final_state=["pi0", "pi0", "pi0"])
         problem_sets = stm.create_problem_sets()
         assert sorted(problem_sets) == expected_strengths
+
+    def test_fast_solving_mode(self):
+        def count_transitions(solving_mode: SolvingMode) -> int:
+            stm = StateTransitionManager(
+                initial_state=["J/psi(1S)"],
+                final_state=["gamma", "pi0", "pi0"],
+                solving_mode=solving_mode,
+            )
+            reaction = stm.find_solutions(stm.create_problem_sets())
+            return len(reaction.transitions)
+
+        assert count_transitions(SolvingMode.FULL) == 294
+        assert count_transitions(SolvingMode.FAST) == 90
 
     def test_regex_pattern(self):
         stm = StateTransitionManager(


### PR DESCRIPTION
- Closes #356 
- Closes #357 

## ⚠️ Interface changes

| Old name                                 | New name                                      |
| ---------------------------------------- | --------------------------------------------- |
| `StateTransitionManager.reaction_mode`   | `StateTransitionManager.solving_mode`         |

The attribute now stores the `SolvingMode` enum itself instead of `str(solving_mode)`, so code that compared it against a string no longer works.

## ❗ Behavioral changes

- The default `solving_mode` of `StateTransitionManager` is now `SolvingMode.FULL` instead of `SolvingMode.FAST`. `FAST` never had any effect before, so the previous default silently behaved as `FULL`; making it explicit keeps the default output unchanged now that `FAST` works.
- `create_problem_sets()` now takes the initial state into account when determining interaction types, so reactions with a photon or lepton in the initial state produce fewer problem sets and therefore fewer solutions. For $\gamma \to \pi^0 \pi^0 \pi^0$ the interaction strengths drop from `[1e-08, 0.0001, 0.006, 1.0, 60.0, 3600.0]` to the electromagnetic-only `[0.0001, 1.0, 60.0]`.

## 🐛 Bug fixes

- `__determine_graph_settings()` collected the ingoing edges of a node with `get_edge_ids_outgoing_from_node()`, so `in_states` was always empty and `LeptonCheck` and `GammaCheck` could only restrict interaction types based on decay products. It now uses `get_edge_ids_ingoing_to_node()`.
- `SolvingMode.FAST` is now honored: the mode is stored as an enum rather than a string, and the loop in `find_quantum_number_transitions()` breaks only once an interaction-strength group has actually produced solutions, instead of as soon as it has been processed.

## Squash commit messages

```text
* BEHAVIOR: determine interaction types from ingoing edges
* BREAK: honor solving_mode in StateTransitionManager
```