### PR TITLE
FIX: serialize particle collections sorted by name

### DIFF
--- a/src/qrules/io/_dict.py
+++ b/src/qrules/io/_dict.py
@@ -17,7 +17,18 @@ from qrules.transition import ReactionInfo, State
 
 
 def from_particle_collection(particles: ParticleCollection) -> dict:
-    return {"particles": [from_attrs_decorated(p) for p in particles]}
+    """Serialize a `.ParticleCollection`, sorted by particle name.
+
+    A `.ParticleCollection` iterates in the order in which particles were added, so
+    serializing it as-is makes the output depend on how the caller built it. Sorting by
+    name keeps the serialization a function of the particles alone, which matters when
+    it is used as a cache key or compared between runs.
+    """
+    return {
+        "particles": [
+            from_attrs_decorated(p) for p in sorted(particles, key=lambda p: p.name)
+        ]
+    }
 
 
 def from_attrs_decorated(inst: Any) -> dict:

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -5,6 +5,15 @@ from qrules.particle import ParticleCollection
 
 
 def describe_serialization():
+    def it_sorts_particles_by_name(particle_selection: ParticleCollection):
+        names = [p["name"] for p in io.asdict(particle_selection)["particles"]]
+        assert names == sorted(names)
+
+    def it_ignores_insertion_order(particle_selection: ParticleCollection):
+        reversed_collection = ParticleCollection()
+        reversed_collection.update(reversed(list(particle_selection)))
+        assert io.asdict(reversed_collection) == io.asdict(particle_selection)
+
     def it_not_implemented_errors(
         output_dir: str, particle_selection: ParticleCollection
     ):


### PR DESCRIPTION
Closes #372

## 🐛 Bug fixes

- `from_particle_collection()` now sorts particles by name, so that `io.asdict()` and the `io.write()` formats built on it depend only on the particles in a `ParticleCollection`, not on the order in which they were added. Two collections that compare equal now serialize identically. This makes a digest over the serialized collection stable across processes, which matters where it is used as a cache key: adding particles from a `set` previously produced a different order under every `PYTHONHASHSEED`.

## ❗ Behavioral changes

- The order of every serialized `ParticleCollection` changes. YAML and JSON files written by earlier versions differ from newly written ones, and any digest taken over that output changes once. Round-tripping is unaffected, because `fromdict()` rebuilds the collection from the list.